### PR TITLE
chore: move get_verified_packed_client_and_proof_update out of ckb-ch…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,3 @@ mc.log
 
 # Ignore OSX .DS_Store file
 .DS_Store
-
-# Ignore generated rocksdb storage folder
-test_storage/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ mc.log
 
 # Ignore OSX .DS_Store file
 .DS_Store
+
+# Ignore generated rocksdb storage folder
+test_storage/

--- a/crates/relayer/src/chain/ckb.rs
+++ b/crates/relayer/src/chain/ckb.rs
@@ -135,6 +135,7 @@ impl CkbChain {
                 &tx_assembler_address,
                 packed_client,
                 packed_proof_update,
+                &self.config.lightclient_lock_typeargs,
                 &self.config.lightclient_contract_typeargs,
                 &self.config.id.to_string(),
             ))?;

--- a/crates/relayer/src/chain/ckb.rs
+++ b/crates/relayer/src/chain/ckb.rs
@@ -1,23 +1,14 @@
 use ckb_jsonrpc_types::OutputsValidator;
 use ckb_sdk::{Address, AddressPayload, NetworkType};
 use eth2_types::MainnetEthSpec;
-use eth_light_client_in_ckb_verification::{
-    mmr,
-    types::{
-        core::{Client as EthLcClient, Header as EthLcHeader},
-        packed::{self, Client as PackedClient, ProofUpdate as PackedProofUpdate},
-        prelude::*,
-    },
-};
-use ibc_relayer_storage::{error::Error as StorageError, prelude::*, Storage};
+use ibc_relayer_storage::Storage;
 use ibc_relayer_types::clients::ics07_ckb::{
     client_state::ClientState as CkbClientState,
     consensus_state::ConsensusState as CkbConsensusState, header::Header as CkbHeader,
     light_block::LightBlock as CkbLightBlock,
 };
 use ibc_relayer_types::clients::ics07_eth::{
-    client_state::ClientState as EthClient,
-    types::{Header as EthHeader, Update as EthUpdate},
+    client_state::ClientState as EthClient, types::Update as EthUpdate,
 };
 use ibc_relayer_types::{
     core::{
@@ -35,7 +26,6 @@ use ibc_relayer_types::{
 };
 use semver::Version;
 use std::sync::{Arc, RwLock};
-use tendermint_light_client::errors::Error as LightClientError;
 use tendermint_rpc::endpoint::broadcast::tx_sync::Response;
 use tokio::runtime::Runtime as TokioRuntime;
 
@@ -76,6 +66,7 @@ mod assembler;
 mod communication;
 mod helper;
 mod signer;
+mod utils;
 
 #[cfg(test)]
 mod mock_rpc_client;
@@ -125,8 +116,17 @@ impl CkbChain {
         &mut self,
         header_updates: Vec<EthUpdate>,
     ) -> Result<Vec<IbcEventWithHeight>, Error> {
+        let onchain_packed_client_opt = self.rt.block_on(self.rpc_client.fetch_packed_client(
+            &self.config.lightclient_contract_typeargs,
+            &self.config.id.to_string(),
+        ))?;
         let (packed_client, packed_proof_update) =
-            self.get_verified_packed_client_and_proof_update(header_updates)?;
+            utils::get_verified_packed_client_and_proof_update(
+                &self.id().to_string(),
+                header_updates,
+                &self.storage,
+                onchain_packed_client_opt,
+            )?;
 
         let tx_assembler_address = self.tx_assembler_address()?;
         let (tx, inputs) = self
@@ -151,165 +151,6 @@ impl CkbChain {
             .map_err(|e| Error::rpc_response(e.to_string()))?;
 
         Ok(vec![])
-    }
-
-    pub(self) fn get_verified_packed_client_and_proof_update(
-        &self,
-        header_updates: Vec<EthUpdate>,
-    ) -> Result<(PackedClient, PackedProofUpdate), Error> {
-        if header_updates.is_empty() {
-            return Err(Error::empty_upgraded_client_state());
-        }
-        let start_slot = header_updates[0].finalized_header.slot;
-        for (i, item) in header_updates.iter().enumerate() {
-            if item.finalized_header.slot != i as u64 + start_slot {
-                return Err(Error::send_tx("uncontinuous header slot".to_owned()));
-            }
-        }
-
-        let mut is_creation = true;
-        // Check the tip in storage and the tip in the client cell are the same.
-        if let Some(stored_tip_slot) = self.storage.get_tip_beacon_header_slot()? {
-            if start_slot != stored_tip_slot + 1 {
-                let height = (stored_tip_slot + 1).try_into().expect("slot too big");
-                return Err(Error::light_client_verification(
-                    self.id().to_string(),
-                    LightClientError::missing_last_block_id(height),
-                ));
-            }
-            is_creation = false;
-        }
-        let onchain_packed_client_opt = self.rt.block_on(self.rpc_client.fetch_packed_client(
-            &self.config.lightclient_contract_typeargs,
-            &self.config.id.to_string(),
-        ))?;
-
-        if is_creation != onchain_packed_client_opt.is_none() {
-            return Err(Error::send_tx(
-                "storage and the chain state is not same".to_owned(),
-            ));
-        }
-
-        if let Some(ref client) = onchain_packed_client_opt {
-            let onchain_tip_slot: u64 = client.maximal_slot().unpack();
-            if start_slot != onchain_tip_slot + 1 {
-                let height = (onchain_tip_slot + 1).try_into().expect("slot too big");
-                return Err(Error::light_client_verification(
-                    self.id().to_string(),
-                    LightClientError::missing_last_block_id(height),
-                ));
-            }
-        }
-
-        let finalized_headers = header_updates
-            .iter()
-            .map(|update| {
-                let EthHeader {
-                    slot,
-                    proposer_index,
-                    parent_root,
-                    state_root,
-                    body_root,
-                } = update.finalized_header.clone();
-                let header = EthLcHeader {
-                    slot,
-                    proposer_index,
-                    parent_root,
-                    state_root,
-                    body_root,
-                };
-                header.calc_cache()
-            })
-            .collect::<Vec<_>>();
-
-        let minimal_slot = self
-            .storage
-            .get_base_beacon_header_slot()?
-            .unwrap_or(start_slot);
-        let last_finalized_header = &finalized_headers[finalized_headers.len() - 1];
-        let maximal_slot = last_finalized_header.inner.slot;
-
-        // Saves all header digests into storage for MMR.
-        {
-            let mut finalized_headers_iter = finalized_headers.iter();
-
-            let mut last_slot = if self.storage.is_initialized()? {
-                start_slot - 1
-            } else {
-                let first = finalized_headers_iter.next().expect("checked");
-                self.storage
-                    .initialize_with(first.inner.slot, first.digest())?;
-                self.storage.put_tip_beacon_header_slot(first.inner.slot)?;
-                first.inner.slot
-            };
-
-            let mut mmr = self.storage.chain_root_mmr(last_slot)?;
-
-            for header in finalized_headers_iter {
-                last_slot = header.inner.slot;
-                mmr.push(header.digest()).map_err(StorageError::from)?;
-            }
-            mmr.commit().map_err(StorageError::from)?;
-
-            self.storage.put_tip_beacon_header_slot(last_slot)?;
-        };
-
-        // Gets the new root and a proof for all new headers.
-        let (packed_headers_mmr_root, packed_headers_mmr_proof) = {
-            let positions = (start_slot..=maximal_slot)
-                .into_iter()
-                .map(|slot| mmr::lib::leaf_index_to_pos(slot - minimal_slot))
-                .collect::<Vec<_>>();
-
-            let mmr = self.storage.chain_root_mmr(maximal_slot)?;
-
-            let headers_mmr_root = mmr.get_root().map_err(StorageError::from)?;
-            let headers_mmr_proof_items = mmr
-                .gen_proof(positions)
-                .map_err(StorageError::from)?
-                .proof_items()
-                .iter()
-                .map(Clone::clone)
-                .collect::<Vec<_>>();
-            let headers_mmr_proof = packed::MmrProof::new_builder()
-                .set(headers_mmr_proof_items)
-                .build();
-
-            (headers_mmr_root, headers_mmr_proof)
-        };
-
-        // Build the packed proof update.
-        let packed_proof_update = {
-            let updates_items = finalized_headers
-                .iter()
-                .map(|header| {
-                    packed::FinalityUpdate::new_builder()
-                        .finalized_header(header.inner.pack())
-                        .build()
-                })
-                .collect::<Vec<_>>();
-            let updates = packed::FinalityUpdateVec::new_builder()
-                .set(updates_items)
-                .build();
-            packed::ProofUpdate::new_builder()
-                .new_headers_mmr_root(packed_headers_mmr_root)
-                .new_headers_mmr_proof(packed_headers_mmr_proof)
-                .updates(updates)
-                .build()
-        };
-
-        // Invoke verification from core::Client on packed_proof_update
-        let client = if let Some(client) = onchain_packed_client_opt {
-            client
-                .unpack()
-                .try_apply_packed_proof_update(packed_proof_update.as_reader())
-                .map_err(|_| Error::send_tx("failed to update header".to_owned()))?
-        } else {
-            EthLcClient::new_from_packed_proof_update(packed_proof_update.as_reader())
-                .map_err(|_| Error::send_tx("failed to create header".to_owned()))?
-        };
-
-        Ok((client.pack(), packed_proof_update))
     }
 
     pub fn network(&self) -> Result<NetworkType, Error> {

--- a/crates/relayer/src/chain/ckb/assembler.rs
+++ b/crates/relayer/src/chain/ckb/assembler.rs
@@ -1,7 +1,11 @@
 #![allow(dead_code)]
 
 use async_trait::async_trait;
-use ckb_sdk::{constants::TYPE_ID_CODE_HASH, traits::PrimaryScriptType, Address};
+use ckb_sdk::{
+    constants::TYPE_ID_CODE_HASH,
+    traits::{LiveCell, PrimaryScriptType},
+    Address,
+};
 use ckb_types::{
     core::{Capacity, DepType, ScriptHashType, TransactionView},
     packed,
@@ -18,6 +22,42 @@ use super::{
 };
 use crate::error::Error;
 
+fn make_typeid_script(type_args: Vec<u8>) -> packed::Script {
+    packed::Script::new_builder()
+        .code_hash(TYPE_ID_CODE_HASH.0.pack())
+        .hash_type(ScriptHashType::Type.into())
+        .args(type_args.pack())
+        .build()
+}
+
+fn make_lightclient_script(script_typehash: packed::Byte32, args: Vec<u8>) -> packed::Script {
+    packed::Script::new_builder()
+        .code_hash(script_typehash)
+        .hash_type(ScriptHashType::Type.into())
+        .args(args.pack())
+        .build()
+}
+
+async fn search_contract_cell<S: CellSearcher + Sync + ?Sized>(
+    searcher: &S,
+    script: &packed::Script,
+    typeid_args: &H256,
+) -> Result<LiveCell, Error> {
+    let contract = searcher
+        .search_cell(script, PrimaryScriptType::Type)
+        .await?;
+    let cell = match contract {
+        Some(cell) => cell,
+        None => {
+            return Err(Error::rpc_response(format!(
+                "contract not found: {}",
+                hex::encode(typeid_args)
+            )));
+        }
+    };
+    Ok(cell)
+}
+
 #[async_trait]
 pub trait TxAssembler: CellSearcher + TxCompleter {
     async fn fetch_packed_client(
@@ -25,11 +65,7 @@ pub trait TxAssembler: CellSearcher + TxCompleter {
         contract_typeid_args: &H256,
         client_id: &String,
     ) -> Result<Option<PackedClient>, Error> {
-        let contract_typescript = packed::Script::new_builder()
-            .code_hash(TYPE_ID_CODE_HASH.0.pack())
-            .hash_type(ScriptHashType::Type.into())
-            .args(contract_typeid_args.as_bytes().to_vec().pack())
-            .build();
+        let contract_typescript = make_typeid_script(contract_typeid_args.as_bytes().to_vec());
         let type_hash = contract_typescript.calc_script_hash();
         let lightclient_cell_opt = self
             .search_cell_by_typescript(&type_hash, &client_id.as_bytes().to_vec())
@@ -51,43 +87,43 @@ pub trait TxAssembler: CellSearcher + TxCompleter {
         address: &Address,
         packed_client: PackedClient,
         packed_proof_update: PackedProofUpdate,
+        lock_typeid_args: &H256,
         contract_typeid_args: &H256,
         client_id: &String,
     ) -> Result<(TransactionView, Vec<packed::CellOutput>), Error> {
-        let contract_typescript = packed::Script::new_builder()
-            .code_hash(TYPE_ID_CODE_HASH.0.pack())
-            .hash_type(ScriptHashType::Type.into())
-            .args(contract_typeid_args.as_bytes().to_vec().pack())
-            .build();
-        let contract_cell = {
-            let contract = self
-                .search_cell(&contract_typescript, PrimaryScriptType::Type)
-                .await?;
-            match contract {
-                Some(cell) => cell,
-                None => {
-                    return Err(Error::rpc_response(format!(
-                        "contract not found: {}",
-                        hex::encode(contract_typeid_args)
-                    )));
-                }
-            }
+        // Find celldeps by searching live cells according typeid_args
+        let contract_typescript = make_typeid_script(contract_typeid_args.as_bytes().to_vec());
+        let contract_cell_dep = {
+            let contract_cell =
+                search_contract_cell(self, &contract_typescript, contract_typeid_args).await?;
+            packed::CellDep::new_builder()
+                .out_point(contract_cell.out_point)
+                .dep_type(DepType::Code.into())
+                .build()
         };
-        let contract_cell_dep = packed::CellDep::new_builder()
-            .out_point(contract_cell.out_point)
-            .dep_type(DepType::Code.into())
-            .build();
-
-        let type_hash = contract_typescript.calc_script_hash();
+        let mock_lockscript = make_typeid_script(lock_typeid_args.as_bytes().to_vec());
+        let mock_lock_celldep = {
+            let mock_cell = search_contract_cell(self, &mock_lockscript, lock_typeid_args).await?;
+            packed::CellDep::new_builder()
+                .out_point(mock_cell.out_point)
+                .dep_type(DepType::Code.into())
+                .build()
+        };
+        // Search light-client cell by lightclient contract type_id hash
+        let contract_typehash = contract_typescript.calc_script_hash();
         let lightclient_cell_opt = self
-            .search_cell_by_typescript(&type_hash, &client_id.as_bytes().to_vec())
+            .search_cell_by_typescript(&contract_typehash, &client_id.as_bytes().to_vec())
             .await?;
-
+        // Build Lightclient Lockscript and Typescript
+        let lightclient_lock =
+            make_lightclient_script(mock_lockscript.calc_script_hash(), Vec::new());
+        let lightclient_type =
+            make_lightclient_script(contract_typehash, client_id.clone().into_bytes());
+        // Assemble Lightclient output cell
         let output_data = packed_client.as_slice().pack();
         let output_cell = packed::CellOutput::new_builder()
-            // TODO set the mock lock script for client cell
-            //.lock(lock)
-            .type_(Some(contract_typescript).pack())
+            .lock(lightclient_lock)
+            .type_(Some(lightclient_type).pack())
             .build_exact_capacity(Capacity::bytes(output_data.len()).unwrap())
             .expect("build ibc contract output");
         let mut inputs_cell_as_output = vec![];
@@ -98,7 +134,7 @@ pub trait TxAssembler: CellSearcher + TxCompleter {
             inputs_capacity += Unpack::<u64>::unpack(&lightclient_cell.output.capacity());
             inputs_cell_as_output.push(lightclient_cell.output);
         }
-
+        // Assemble Lightclient witness
         let witness = {
             let input_type_args = packed::BytesOpt::new_builder()
                 .set(Some(packed_proof_update.as_slice().pack()))
@@ -108,18 +144,20 @@ pub trait TxAssembler: CellSearcher + TxCompleter {
                 .build();
             witness_args.as_bytes()
         };
+        // Assemble transaction
         let tx = TransactionView::new_advanced_builder()
             .inputs(inputs_cell)
             .output(output_cell)
             .output_data(output_data)
             .witness(witness.pack())
             .cell_dep(contract_cell_dep)
+            .cell_dep(mock_lock_celldep)
             .build();
         let fee_rate = 1000;
         let (tx, mut new_inputs) = self
             .complete_tx_with_secp256k1_change(tx, address, inputs_capacity, fee_rate)
             .await?;
-
+        // Collect input cells to support signing process (calculating input group)
         inputs_cell_as_output.append(&mut new_inputs);
         Ok((tx, inputs_cell_as_output))
     }

--- a/crates/relayer/src/chain/ckb/assembler.rs
+++ b/crates/relayer/src/chain/ckb/assembler.rs
@@ -115,8 +115,9 @@ pub trait TxAssembler: CellSearcher + TxCompleter {
             .search_cell_by_typescript(&contract_typehash, &client_id.as_bytes().to_vec())
             .await?;
         // Build Lightclient Lockscript and Typescript
+        let pubkey_hash = address.payload().args();
         let lightclient_lock =
-            make_lightclient_script(mock_lockscript.calc_script_hash(), Vec::new());
+            make_lightclient_script(mock_lockscript.calc_script_hash(), pubkey_hash.to_vec());
         let lightclient_type =
             make_lightclient_script(contract_typehash, client_id.clone().into_bytes());
         // Assemble Lightclient output cell

--- a/crates/relayer/src/chain/ckb/tests.rs
+++ b/crates/relayer/src/chain/ckb/tests.rs
@@ -77,6 +77,7 @@ fn test_update_eth_client() {
             ckb_rpc: Url::from_str("http://ckb_rpc").unwrap(),
             ckb_indexer_rpc: Url::from_str("http://ckb_indexer_rpc").unwrap(),
             lightclient_contract_typeargs: h256!("0x123"),
+            lightclient_lock_typeargs: h256!("0x123"),
             key_name: "ckb-chain-test".to_string(),
             data_dir: tmp_dir.path().to_path_buf(),
         };

--- a/crates/relayer/src/chain/ckb/utils.rs
+++ b/crates/relayer/src/chain/ckb/utils.rs
@@ -180,7 +180,7 @@ mod tests {
     use eyre::Result;
     use ibc_relayer_storage::Storage;
     use std::fs;
-    use std::path::Path;
+    use tempfile::TempDir;
 
     fn load_updates_from_file(path: &str) -> Result<Vec<EthUpdate>> {
         let headers_json = fs::read_to_string(path)?;
@@ -193,10 +193,7 @@ mod tests {
 
     #[test]
     fn test_get_verified_packed_client_and_proof_update() {
-        let path = Path::new("test_storage");
-        if path.is_dir() {
-            fs::remove_dir_all(path).unwrap();
-        }
+        let path = TempDir::new().unwrap();
         let storage: Storage<MainnetEthSpec> = Storage::new(path).unwrap();
         let chain_id = "chain_id".to_string();
 

--- a/crates/relayer/src/chain/ckb/utils.rs
+++ b/crates/relayer/src/chain/ckb/utils.rs
@@ -187,7 +187,7 @@ mod tests {
         let headers: Vec<EthHeader> = serde_json::from_str(&headers_json)?;
         Ok(headers
             .into_iter()
-            .map(|h| EthUpdate::from_finalized_header(h))
+            .map(EthUpdate::from_finalized_header)
             .collect::<Vec<_>>())
     }
 

--- a/crates/relayer/src/chain/ckb/utils.rs
+++ b/crates/relayer/src/chain/ckb/utils.rs
@@ -1,0 +1,223 @@
+use eth2_types::EthSpec;
+use eth_light_client_in_ckb_verification::mmr;
+use eth_light_client_in_ckb_verification::types::{
+    core::{Client as EthLcClient, Header as EthLcHeader},
+    packed::{self, Client as PackedClient, ProofUpdate as PackedProofUpdate},
+    prelude::*,
+};
+use ibc_relayer_storage::{
+    error::Error as StorageError,
+    prelude::{StorageAsMMRStore, StorageReader, StorageWriter},
+};
+use ibc_relayer_types::clients::ics07_eth::types::{Header as EthHeader, Update as EthUpdate};
+use tendermint_light_client::errors::Error as LightClientError;
+
+use crate::error::Error;
+
+pub fn get_verified_packed_client_and_proof_update<S, E>(
+    chain_id: &String,
+    header_updates: Vec<EthUpdate>,
+    storage: &S,
+    onchain_packed_client_opt: Option<PackedClient>,
+) -> Result<(PackedClient, PackedProofUpdate), Error>
+where
+    S: StorageReader<E> + StorageWriter<E> + StorageAsMMRStore<E>,
+    E: EthSpec,
+{
+    if header_updates.is_empty() {
+        return Err(Error::empty_upgraded_client_state());
+    }
+    let start_slot = header_updates[0].finalized_header.slot;
+    for (i, item) in header_updates.iter().enumerate() {
+        if item.finalized_header.slot != i as u64 + start_slot {
+            return Err(Error::send_tx("uncontinuous header slot".to_owned()));
+        }
+    }
+
+    let mut is_creation = true;
+    // Check the tip in storage and the tip in the client cell are the same.
+    if let Some(stored_tip_slot) = storage.get_tip_beacon_header_slot()? {
+        if start_slot != stored_tip_slot + 1 {
+            let height = (stored_tip_slot + 1).try_into().expect("slot too big");
+            return Err(Error::light_client_verification(
+                chain_id.to_string(),
+                LightClientError::missing_last_block_id(height),
+            ));
+        }
+        is_creation = false;
+    }
+
+    if is_creation != onchain_packed_client_opt.is_none() {
+        return Err(Error::send_tx(
+            "storage and the chain state is not same".to_owned(),
+        ));
+    }
+
+    if let Some(ref client) = onchain_packed_client_opt {
+        let onchain_tip_slot: u64 = client.maximal_slot().unpack();
+        if start_slot != onchain_tip_slot + 1 {
+            let height = (onchain_tip_slot + 1).try_into().expect("slot too big");
+            return Err(Error::light_client_verification(
+                chain_id.to_string(),
+                LightClientError::missing_last_block_id(height),
+            ));
+        }
+    }
+
+    let finalized_headers = header_updates
+        .iter()
+        .map(|update| {
+            let EthHeader {
+                slot,
+                proposer_index,
+                parent_root,
+                state_root,
+                body_root,
+            } = update.finalized_header.clone();
+            let header = EthLcHeader {
+                slot,
+                proposer_index,
+                parent_root,
+                state_root,
+                body_root,
+            };
+            header.calc_cache()
+        })
+        .collect::<Vec<_>>();
+
+    let minimal_slot = storage.get_base_beacon_header_slot()?.unwrap_or(start_slot);
+    let last_finalized_header = &finalized_headers[finalized_headers.len() - 1];
+    let maximal_slot = last_finalized_header.inner.slot;
+
+    // Saves all header digests into storage for MMR.
+    {
+        let mut finalized_headers_iter = finalized_headers.iter();
+
+        let mut last_slot = if storage.is_initialized()? {
+            start_slot - 1
+        } else {
+            let first = finalized_headers_iter.next().expect("checked");
+            storage.initialize_with(first.inner.slot, first.digest())?;
+            storage.put_tip_beacon_header_slot(first.inner.slot)?;
+            first.inner.slot
+        };
+
+        let mut mmr = storage.chain_root_mmr(last_slot)?;
+
+        for header in finalized_headers_iter {
+            last_slot = header.inner.slot;
+            mmr.push(header.digest()).map_err(StorageError::from)?;
+        }
+        mmr.commit().map_err(StorageError::from)?;
+
+        storage.put_tip_beacon_header_slot(last_slot)?;
+    };
+
+    // Gets the new root and a proof for all new headers.
+    let (packed_headers_mmr_root, packed_headers_mmr_proof) = {
+        let positions = (start_slot..=maximal_slot)
+            .into_iter()
+            .map(|slot| mmr::lib::leaf_index_to_pos(slot - minimal_slot))
+            .collect::<Vec<_>>();
+
+        let mmr = storage.chain_root_mmr(maximal_slot)?;
+
+        let headers_mmr_root = mmr.get_root().map_err(StorageError::from)?;
+        let headers_mmr_proof_items = mmr
+            .gen_proof(positions)
+            .map_err(StorageError::from)?
+            .proof_items()
+            .iter()
+            .map(Clone::clone)
+            .collect::<Vec<_>>();
+        let headers_mmr_proof = packed::MmrProof::new_builder()
+            .set(headers_mmr_proof_items)
+            .build();
+
+        (headers_mmr_root, headers_mmr_proof)
+    };
+
+    // Build the packed proof update.
+    let packed_proof_update = {
+        let updates_items = finalized_headers
+            .iter()
+            .map(|header| {
+                packed::FinalityUpdate::new_builder()
+                    .finalized_header(header.inner.pack())
+                    .build()
+            })
+            .collect::<Vec<_>>();
+        let updates = packed::FinalityUpdateVec::new_builder()
+            .set(updates_items)
+            .build();
+        packed::ProofUpdate::new_builder()
+            .new_headers_mmr_root(packed_headers_mmr_root)
+            .new_headers_mmr_proof(packed_headers_mmr_proof)
+            .updates(updates)
+            .build()
+    };
+
+    // Invoke verification from core::Client on packed_proof_update
+    let client = if let Some(client) = onchain_packed_client_opt {
+        client
+            .unpack()
+            .try_apply_packed_proof_update(packed_proof_update.as_reader())
+            .map_err(|_| Error::send_tx("failed to update header".to_owned()))?
+    } else {
+        EthLcClient::new_from_packed_proof_update(packed_proof_update.as_reader())
+            .map_err(|_| Error::send_tx("failed to create header".to_owned()))?
+    };
+
+    Ok((client.pack(), packed_proof_update))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_verified_packed_client_and_proof_update;
+    use super::EthHeader;
+    use super::EthUpdate;
+    use eth2_types::MainnetEthSpec;
+    use eyre::Result;
+    use ibc_relayer_storage::Storage;
+    use std::fs;
+    use std::path::Path;
+
+    fn load_updates_from_file(path: &str) -> Result<Vec<EthUpdate>> {
+        let headers_json = fs::read_to_string(path)?;
+        let headers: Vec<EthHeader> = serde_json::from_str(&headers_json)?;
+        Ok(headers
+            .into_iter()
+            .map(|h| EthUpdate::from_finalized_header(h))
+            .collect::<Vec<_>>())
+    }
+
+    #[test]
+    fn test_get_verified_packed_client_and_proof_update() {
+        let path = Path::new("test_storage");
+        if path.is_dir() {
+            fs::remove_dir_all(path).unwrap();
+        }
+        let storage: Storage<MainnetEthSpec> = Storage::new(path).unwrap();
+        let chain_id = "chain_id".to_string();
+
+        // Testing updates for creation of light_client
+        let updates_part_1 =
+            load_updates_from_file("src/testdata/test_update_eth_client/headers-part-1.json")
+                .expect("part_1");
+        let (packed_client, _) =
+            get_verified_packed_client_and_proof_update(&chain_id, updates_part_1, &storage, None)
+                .expect("verify part_1");
+
+        // Testing updates for update of light_client
+        let updates_part_2 =
+            load_updates_from_file("src/testdata/test_update_eth_client/headers-part-2.json")
+                .expect("part_2");
+        get_verified_packed_client_and_proof_update(
+            &chain_id,
+            updates_part_2,
+            &storage,
+            Some(packed_client),
+        )
+        .expect("verify part_2");
+    }
+}

--- a/crates/relayer/src/config/ckb.rs
+++ b/crates/relayer/src/config/ckb.rs
@@ -11,6 +11,7 @@ pub struct ChainConfig {
     pub ckb_rpc: Url,
     pub ckb_indexer_rpc: Url,
     pub lightclient_contract_typeargs: H256,
+    pub lightclient_lock_typeargs: H256,
     pub key_name: String,
     pub data_dir: PathBuf,
 }

--- a/crates/relayer/src/config/eth.rs
+++ b/crates/relayer/src/config/eth.rs
@@ -18,8 +18,8 @@ pub struct EthChainConfig {
     pub key_name: String,
     pub rpc_addr: String,
     pub rpc_port: u16,
-    pub forks: Forks,
     pub max_checkpoint_age: u64,
+    pub forks: Forks,
 }
 
 pub fn array_hex_deserialize<'de, D, const N: usize>(deserializer: D) -> Result<[u8; N], D::Error>

--- a/crates/relayer/tests/config/fixtures/relayer_conf_example.toml
+++ b/crates/relayer/tests/config/fixtures/relayer_conf_example.toml
@@ -59,3 +59,28 @@ clock_drift = '5s'
 trusting_period = '14days'
 trust_threshold = { numerator = '1', denominator = '3' }
 address_type = { derivation = 'ethermint', proto_type = { pk_type = '/injective.crypto.v1beta1.ethsecp256k1.PubKey' } }
+
+[[chains]]
+id = 'ibc-eth-0'
+genesis_time = 1606824023
+genesis_root = "0x4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95"
+websocket_addr = 'wss://eth-mainnet.g.alchemy.com/v2/bP31lpybtbwJkUWRp850Qds3LV86d1Kv'
+initial_checkpoint = "0x428ce0b5f5bbed1fc2b3feb5d4152ae0fe98a80b1bfa8de36681868e81e9222a"
+# key_name = 'connections'
+key_name = 'wallet'
+rpc_addr = 'https://www.lightclientdata.org/'
+rpc_port = 8545
+max_checkpoint_age = 9209600
+[chains.forks]
+genesis = { epoch = 0, fork_version = "0x00000000" }
+altair = { epoch = 74240, fork_version = "0x01000000" }
+bellatrix = { epoch = 144896, fork_version = "0x02000000" }
+
+[[chains]]
+id = 'ibc-ckb-0'
+ckb_rpc = "https://testnet.ckb.dev/"
+ckb_indexer_rpc = "https://testnet.ckb.dev/indexer"
+lightclient_contract_typeargs = "0x81e682d4d6db6b6e552f5ae9db6fcba6dfc395930ff62d86f271a92e433f3a36"
+lightclient_lock_typeargs = "0x81e682d4d6db6b6e552f5ae9db6fcba6dfc395930ff62d86f271a92e433f3a36"
+key_name = "ckb_key_name"
+data_dir = "./ckb_mmr_storage"


### PR DESCRIPTION
## Description
1. move `get_verified_packed_client_and_proof_update` out of ckb-chain endpoint to a single utils.rs file
2. add a test module for testing the standalone `get_verified_packed_client_and_proof_update` functionality
3. find there are errors in assembling the lightclient output cell, change the `mock-lock` and `client-type` script assembly parameters

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
