### PR TITLE
bug: replace todo!() with workable codes in keyring module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ mc.log
 
 # Ignore OSX .DS_Store file
 .DS_Store
+
+# Ignore native MMR storage
+ckb_mmr_storage/

--- a/crates/relayer-cli/src/commands/keys/add.rs
+++ b/crates/relayer-cli/src/commands/keys/add.rs
@@ -198,25 +198,24 @@ pub fn add_key(
     hd_path: &StandardHDPath,
     overwrite: bool,
 ) -> eyre::Result<AnySigningKeyPair> {
-    let key_pair = match config.r#type() {
-        ChainType::CosmosSdk => {
-            let mut keyring =
-                KeyRing::new_secp256k1(Store::Test, &config.cosmos().account_prefix, config.id())?;
-
-            check_key_exists(&keyring, key_name, overwrite);
-
-            let key_contents =
-                fs::read_to_string(file).map_err(|_| eyre!("error reading the key file"))?;
-            let key_pair = Secp256k1KeyPair::from_seed_file(&key_contents, hd_path)?;
-
-            keyring.add_key(key_name, key_pair.clone())?;
-            key_pair.into()
-        }
-        ChainType::Eth => todo!(),
-        ChainType::Axon => todo!(),
-        ChainType::Ckb => todo!(),
+    let account_prefix = match config.r#type() {
+        ChainType::CosmosSdk => &config.cosmos().account_prefix,
+        ChainType::Eth => "eth",
+        ChainType::Axon => "axon",
+        ChainType::Ckb => "ckb",
     };
+    let key_pair = {
+        let mut keyring = KeyRing::new_secp256k1(Store::Test, account_prefix, config.id())?;
 
+        check_key_exists(&keyring, key_name, overwrite);
+
+        let key_contents =
+            fs::read_to_string(file).map_err(|_| eyre!("error reading the key file"))?;
+        let key_pair = Secp256k1KeyPair::from_seed_file(&key_contents, hd_path)?;
+
+        keyring.add_key(key_name, key_pair.clone())?;
+        key_pair.into()
+    };
     Ok(key_pair)
 }
 
@@ -230,28 +229,27 @@ pub fn restore_key(
     let mnemonic_content =
         fs::read_to_string(mnemonic).map_err(|_| eyre!("error reading the mnemonic file"))?;
 
-    let key_pair = match config.r#type() {
-        ChainType::CosmosSdk => {
-            let mut keyring =
-                KeyRing::new_secp256k1(Store::Test, &config.cosmos().account_prefix, config.id())?;
-
-            check_key_exists(&keyring, key_name, overwrite);
-
-            let key_pair = Secp256k1KeyPair::from_mnemonic(
-                &mnemonic_content,
-                hdpath,
-                &config.cosmos().address_type,
-                keyring.account_prefix(),
-            )?;
-
-            keyring.add_key(key_name, key_pair.clone())?;
-            key_pair.into()
-        }
-        ChainType::Eth => todo!(),
-        ChainType::Axon => todo!(),
-        ChainType::Ckb => todo!(),
+    let account_prefix = match config.r#type() {
+        ChainType::CosmosSdk => &config.cosmos().account_prefix,
+        ChainType::Eth => "eth",
+        ChainType::Axon => "axon",
+        ChainType::Ckb => "ckb",
     };
+    let key_pair = {
+        let mut keyring = KeyRing::new_secp256k1(Store::Test, account_prefix, config.id())?;
 
+        check_key_exists(&keyring, key_name, overwrite);
+
+        let key_pair = Secp256k1KeyPair::from_mnemonic(
+            &mnemonic_content,
+            hdpath,
+            &config.cosmos().address_type,
+            keyring.account_prefix(),
+        )?;
+
+        keyring.add_key(key_name, key_pair.clone())?;
+        key_pair.into()
+    };
     Ok(key_pair)
 }
 

--- a/crates/relayer/src/chain/ckb.rs
+++ b/crates/relayer/src/chain/ckb.rs
@@ -1,4 +1,4 @@
-use ckb_jsonrpc_types::OutputsValidator;
+use ckb_jsonrpc_types::{OutputsValidator, TransactionView as JsonTx};
 use ckb_sdk::{Address, AddressPayload, NetworkType};
 use eth2_types::MainnetEthSpec;
 use ibc_relayer_storage::Storage;
@@ -149,7 +149,13 @@ impl CkbChain {
                 self.rpc_client
                     .send_transaction(&tx.data().into(), Some(OutputsValidator::Passthrough)),
             )
-            .map_err(|e| Error::rpc_response(e.to_string()))?;
+            .map_err(|e| {
+                Error::rpc_response(format!(
+                    "{}\n==[json transaction is below]==\n{}",
+                    e,
+                    serde_json::to_string(&JsonTx::from(tx)).expect("jsonify ckb tx")
+                ))
+            })?;
 
         Ok(vec![])
     }

--- a/crates/relayer/src/keyring.rs
+++ b/crates/relayer/src/keyring.rs
@@ -281,19 +281,19 @@ impl KeyRing<Ed25519KeyPair> {
 }
 
 pub fn list_keys(config: &ChainConfig) -> Result<Vec<(String, AnySigningKeyPair)>, Error> {
-    let keys = match config.r#type() {
-        ChainType::CosmosSdk => {
-            let keyring =
-                KeyRing::new_secp256k1(Store::Test, &config.cosmos().account_prefix, config.id())?;
-            keyring
-                .keys()?
-                .into_iter()
-                .map(|(key_name, keys)| (key_name, keys.into()))
-                .collect()
-        }
-        ChainType::Eth => todo!(),
-        ChainType::Axon => todo!(),
-        ChainType::Ckb => todo!(),
+    let account_prefix = match config.r#type() {
+        ChainType::CosmosSdk => &config.cosmos().account_prefix,
+        ChainType::Eth => "eth",
+        ChainType::Axon => "axon",
+        ChainType::Ckb => "ckb",
+    };
+    let keys = {
+        let keyring = KeyRing::new_secp256k1(Store::Test, account_prefix, config.id())?;
+        keyring
+            .keys()?
+            .into_iter()
+            .map(|(key_name, keys)| (key_name, keys.into()))
+            .collect()
     };
     Ok(keys)
 }

--- a/crates/relayer/src/testdata/header.json
+++ b/crates/relayer/src/testdata/header.json
@@ -1,0 +1,17 @@
+{
+    "execution_optimistic": true,
+    "data": {
+        "root": "0x3f00a700bb5b62d4af635060862d8b846eaa5317ec4130dc811f1b5ed7b3613e",
+        "canonical": true,
+        "header": {
+            "message": {
+                "slot": "5595002",
+                "proposer_index": "353158",
+                "parent_root": "0xf8902dc4da5c9df239e02a300e8e3524b1339b063a2334769929d2e5da08ccb2",
+                "state_root": "0x706eaec53cd35773552c49af68b76899a6e02beb275a189df9f2e5ef871b2b21",
+                "body_root": "0x66055154f25d493e3d098305c5ff92113d14d2288b4886351f6f5a022c9c4da5"
+            },
+            "signature": "0x8ff2ded8dbe5ab2ad61e9c84369ce733b7f7977cbade67846da841f573ad1068047254498d2fa5f46a6fa10d0dc4e9d419a355a1768486401f21ca7262124e44b1c3a0de075d6542ab3c3d3e03186be447b166fcef1263c4a182362263fa0986"
+        }
+    }
+}

--- a/crates/relayer/tests/config/fixtures/relayer_conf_example.toml
+++ b/crates/relayer/tests/config/fixtures/relayer_conf_example.toml
@@ -68,7 +68,7 @@ websocket_addr = 'wss://eth-mainnet.g.alchemy.com/v2/bP31lpybtbwJkUWRp850Qds3LV8
 initial_checkpoint = "0xe4d168932628537930f29f3022dc3b2cd51e77b25b86ea635c7449c41cfd0779"
 # key_name = 'connections'
 key_name = 'relayer_eth_wallet'
-rpc_addr = 'https://www.lightclientdata.org/'
+rpc_addr = 'https://www.lightclientdata.org'
 rpc_port = 8545
 max_checkpoint_age = 9209600
 [chains.forks]


### PR DESCRIPTION
feat: add get_header() interface testcase for eth lightclient module

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description
1. `hermes` would be crashed for `todo!()` while running `keys` subcommand for the CKB chain, so this needs to solve
2. add testcase for `get_header()` interface in NimbusRpc
3. fix some bugs preventing `hermes` startups from successfully, but also remains at least 2 bugs:
- [ ] ckb `send_transaction` would fail with return code -22 while executing `Inputs[0].Lock` which is an normal secp256k1_sighash_all cell 
![image](https://user-images.githubusercontent.com/3871265/212930830-4928a540-2560-4edb-8c59-1c9481e3ee2c.png)
- [ ] despite whether `send_transaction` failed, the MMR storage would store the ETH header data, which can be recognized it's not **Transaction Safe** in the batch consisting of storing headers and sending ckb transaction, this needs to be solved just like adding **Transaction Safe** feature into a DB system

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
