### PR TITLE
chore(deps): bump eth-light-client-in-ckb to latest revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "eth_light_client_in_ckb-verification"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/yangby-cryptape/eth-light-client-in-ckb?rev=42056c5#42056c567ad3afac22fc343f0bb6bf0ff1893f0e"
+source = "git+https://github.com/yangby-cryptape/eth-light-client-in-ckb?rev=76a7e5c#76a7e5c5532dfb7f6e0a9485ec98a8ad50a81a01"
 dependencies = [
  "ckb-merkle-mountain-range",
  "eth2_hashing",

--- a/crates/relayer-storage/Cargo.toml
+++ b/crates/relayer-storage/Cargo.toml
@@ -15,4 +15,4 @@ description  = "The storage part of SynapseWeb3 IBC Relayer"
 thiserror = "1.0.37"
 rocksdb = { package = "ckb-rocksdb", version ="=0.19.0", default-features = false, features = ["snappy"] }
 eth2_types = { git = "https://github.com/yangby-cryptape/lighthouse", rev = "62dc610", package = "types" }
-eth_light_client_in_ckb-verification = { git = "https://github.com/yangby-cryptape/eth-light-client-in-ckb", rev = "42056c5", package = "eth_light_client_in_ckb-verification" }
+eth_light_client_in_ckb-verification = { git = "https://github.com/yangby-cryptape/eth-light-client-in-ckb", rev = "76a7e5c", package = "eth_light_client_in_ckb-verification" }

--- a/crates/relayer/Cargo.toml
+++ b/crates/relayer/Cargo.toml
@@ -30,7 +30,7 @@ eth2_types       = { git = "https://github.com/yangby-cryptape/lighthouse", rev 
 tree_hash_derive = { git = "https://github.com/yangby-cryptape/lighthouse", rev = "62dc610" }
 tree_hash        = { git = "https://github.com/yangby-cryptape/lighthouse", rev = "62dc610" }
 
-eth_light_client_in_ckb-verification = { git = "https://github.com/yangby-cryptape/eth-light-client-in-ckb", rev = "42056c5", package = "eth_light_client_in_ckb-verification" }
+eth_light_client_in_ckb-verification = { git = "https://github.com/yangby-cryptape/eth-light-client-in-ckb", rev = "76a7e5c", package = "eth_light_client_in_ckb-verification" }
 
 subtle-encoding = "0.5"
 humantime-serde = "1.1.1"


### PR DESCRIPTION
Remove several fields to optimize the size of proof update.

In the unit tests of `eth-light-client-in-ckb`, the new revision reduces the size from 46 KiB to 8032 bytes.