### PR TITLE
feat: rollback the MMR storage when failed to sent client update transaction

### DIFF
--- a/crates/relayer-storage/src/lib.rs
+++ b/crates/relayer-storage/src/lib.rs
@@ -2,7 +2,7 @@ pub mod error;
 pub mod prelude;
 pub mod schemas;
 
-pub(crate) type Slot = u64;
+pub type Slot = u64;
 
 mod storage;
 pub use storage::Storage;

--- a/crates/relayer-storage/src/storage/mod.rs
+++ b/crates/relayer-storage/src/storage/mod.rs
@@ -2,7 +2,8 @@ use std::{marker::PhantomData, path::Path, sync::Arc};
 
 use rocksdb::{
     prelude::{
-        GetColumnFamilys as _, GetPinned as _, GetPinnedCF as _, OpenCF as _, Put as _, PutCF as _,
+        Delete as _, GetColumnFamilys as _, GetPinned as _, GetPinnedCF as _, OpenCF as _,
+        Put as _, PutCF as _,
     },
     ColumnFamily, ColumnFamilyDescriptor, DBPinnableSlice, Options, DB,
 };
@@ -64,6 +65,10 @@ impl<S> Storage<S> {
         self.db
             .put(key.as_ref(), value.as_ref())
             .map_err(Into::into)
+    }
+
+    pub(crate) fn delete<K: AsRef<[u8]>>(&self, key: K) -> Result<()> {
+        self.db.delete(key.as_ref()).map_err(Into::into)
     }
 
     pub(crate) fn get_cf<K: AsRef<[u8]>>(

--- a/crates/relayer-storage/src/storage/writer.rs
+++ b/crates/relayer-storage/src/storage/writer.rs
@@ -29,6 +29,21 @@ where
         self.put(keys::TIP_BEACON_HEADER_SLOT, value.as_slice())
     }
 
+    fn delete_base_beacon_header_slot(&self) -> Result<()> {
+        let mut writer = self
+            .cache
+            .base_beacon_header_slot
+            .write()
+            .map_err(Error::storage)?;
+        self.delete(keys::BASE_BEACON_HEADER_SLOT)?;
+        *writer = None;
+        Ok(())
+    }
+
+    fn delete_tip_beacon_header_slot(&self) -> Result<()> {
+        self.delete(keys::TIP_BEACON_HEADER_SLOT)
+    }
+
     fn put_beacon_header_digest(&self, position: u64, digest: &packed::HeaderDigest) -> Result<()> {
         let key: packed::Uint64 = position.pack();
         self.put_cf(


### PR DESCRIPTION
### Description

- If failed to send the transaction to create the client cell, then clear related data in storage.
- If failed to send the transaction to update the client cell, then rollback the data in storage.