### PR TITLE
bug: original hermes key file will always be recognized as Cosmos key…

### DIFF
--- a/crates/relayer/src/keyring/secp256k1_key_pair.rs
+++ b/crates/relayer/src/keyring/secp256k1_key_pair.rs
@@ -6,6 +6,7 @@ use bitcoin::{
     util::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKey},
 };
 use ckb_hash::blake2b_256;
+use ckb_sdk::{AddressPayload, NetworkType};
 use digest::Digest;
 use generic_array::{typenum::U32, GenericArray};
 use hdpath::StandardHDPath;
@@ -237,6 +238,19 @@ impl Secp256k1KeyPair {
             address_type,
             account,
         })
+    }
+
+    pub fn into_ckb_keypair(self, network: NetworkType) -> Self {
+        if let Secp256k1AddressType::Ckb = self.address_type {
+            return self;
+        }
+        let payload = AddressPayload::from_pubkey(&self.public_key);
+        Self {
+            address: get_address(&self.public_key, Secp256k1AddressType::Ckb),
+            address_type: Secp256k1AddressType::Ckb,
+            account: payload.display_with_network(network, false),
+            ..self
+        }
     }
 
     #[cfg(test)]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description
the default cosmos key-seed.json file will be recognized as cosmos key type which will be marked as `Cosmos`, this will cause the generated signature format mismatch

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
