### PR TITLE
bug: fix mismatch problem between native and onchain slots

### DIFF
--- a/crates/relayer/src/chain/ckb/mock_rpc_client.rs
+++ b/crates/relayer/src/chain/ckb/mock_rpc_client.rs
@@ -2,8 +2,9 @@
 #![allow(unused_variables)]
 
 use ckb_jsonrpc_types::{
-    BlockNumber, BlockView, CellWithStatus, ChainInfo, HeaderView, JsonBytes, OutPoint,
-    OutputsValidator, Transaction, TransactionWithStatusResponse,
+    BlockNumber, BlockView, CellWithStatus, ChainInfo, Header, HeaderView, JsonBytes, OutPoint,
+    OutputsValidator, ResponseFormat, Transaction, TransactionView, TransactionWithStatusResponse,
+    TxStatus,
 };
 use ckb_sdk::rpc::ckb_indexer::{Cell, Pagination, SearchKey};
 use ckb_types::{packed, prelude::*, H256};
@@ -80,15 +81,37 @@ impl CkbReader for RpcClient {
     }
 
     fn get_block(&self, hash: &H256) -> Rpc<BlockView> {
-        todo!()
+        let resp = BlockView {
+            header: HeaderView {
+                inner: Header {
+                    number: 1u64.into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        Box::pin(async { Ok(resp) })
     }
 
     fn get_tip_header(&self) -> Rpc<HeaderView> {
-        todo!()
+        let resp = HeaderView {
+            inner: Header {
+                number: u64::MAX.into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        Box::pin(async { Ok(resp) })
     }
 
     fn get_transaction(&self, hash: &H256) -> Rpc<Option<TransactionWithStatusResponse>> {
-        todo!()
+        let transaction = ResponseFormat::<TransactionView>::json(Default::default());
+        let resp = TransactionWithStatusResponse {
+            transaction: Some(transaction),
+            tx_status: TxStatus::committed(hash.clone()),
+        };
+        Box::pin(async { Ok(Some(resp)) })
     }
 
     fn get_live_cell(&self, out_point: &OutPoint, with_data: bool) -> Rpc<CellWithStatus> {

--- a/crates/relayer/src/chain/ckb/utils.rs
+++ b/crates/relayer/src/chain/ckb/utils.rs
@@ -1,5 +1,7 @@
+use ckb_jsonrpc_types::Status;
+use ckb_types::H256;
 use eth2_types::EthSpec;
-use eth_light_client_in_ckb_verification::mmr;
+use eth_light_client_in_ckb_verification::mmr::{self, HeaderWithCache};
 use eth_light_client_in_ckb_verification::types::{
     core::{Client as EthLcClient, Header as EthLcHeader},
     packed::{self, Client as PackedClient, ProofUpdate as PackedProofUpdate},
@@ -11,64 +13,22 @@ use ibc_relayer_storage::{
     Slot,
 };
 use ibc_relayer_types::clients::ics07_eth::types::{Header as EthHeader, Update as EthUpdate};
+use std::sync::Arc;
+use std::time::Duration;
 use tendermint_light_client::errors::Error as LightClientError;
+use tracing::debug;
 
+use crate::chain::ckb::communication::CkbReader;
 use crate::error::Error;
 
-pub fn get_verified_packed_client_and_proof_update<S, E>(
-    chain_id: &String,
-    header_updates: Vec<EthUpdate>,
-    storage: &S,
-    onchain_packed_client_opt: Option<PackedClient>,
-) -> Result<(Option<Slot>, PackedClient, PackedProofUpdate), Error>
-where
-    S: StorageReader<E> + StorageWriter<E> + StorageAsMMRStore<E>,
-    E: EthSpec,
-{
-    let mut prev_tip_slot = None;
+use super::rpc_client::RpcClient;
 
-    if header_updates.is_empty() {
-        return Err(Error::empty_upgraded_client_state());
-    }
-    let start_slot = header_updates[0].finalized_header.slot;
-    for (i, item) in header_updates.iter().enumerate() {
-        if item.finalized_header.slot != i as u64 + start_slot {
-            return Err(Error::send_tx("uncontinuous header slot".to_owned()));
-        }
-    }
+fn into_height(slot: u64) -> tendermint::block::Height {
+    slot.try_into().expect("slot too big")
+}
 
-    // let mut is_mmr_empty = true;
-    // Check the tip in storage and the tip in the client cell are the same.
-    if let Some(stored_tip_slot) = storage.get_tip_beacon_header_slot()? {
-        if start_slot != stored_tip_slot + 1 {
-            let height = (stored_tip_slot + 1).try_into().expect("slot too big");
-            return Err(Error::light_client_verification(
-                chain_id.to_string(),
-                LightClientError::missing_last_block_id(height),
-            ));
-        }
-        // is_mmr_empty = false;
-    }
-
-    // if is_mmr_empty != onchain_packed_client_opt.is_none() {
-    //     return Err(Error::send_tx(
-    //         "storage and the chain state is not same".to_owned(),
-    //     ));
-    // }
-
-    if let Some(ref client) = onchain_packed_client_opt {
-        let onchain_tip_slot: u64 = client.maximal_slot().unpack();
-        if start_slot != onchain_tip_slot + 1 {
-            let height = (onchain_tip_slot + 1).try_into().expect("slot too big");
-            return Err(Error::light_client_verification(
-                chain_id.to_string(),
-                LightClientError::missing_last_block_id(height),
-            ));
-        }
-        prev_tip_slot = Some(onchain_tip_slot);
-    }
-
-    let finalized_headers = header_updates
+fn into_cached_headers(header_updates: &[EthUpdate]) -> Vec<HeaderWithCache> {
+    header_updates
         .iter()
         .map(|update| {
             let EthHeader {
@@ -87,37 +47,194 @@ where
             };
             header.calc_cache()
         })
-        .collect::<Vec<_>>();
+        .collect::<Vec<_>>()
+}
 
+fn commit_headers_into_mmr_storage<S, E>(
+    finalized_headers: &Vec<HeaderWithCache>,
+    storage: &S,
+) -> Result<(), Error>
+where
+    S: StorageWriter<E> + StorageAsMMRStore<E>,
+    E: EthSpec,
+{
+    if finalized_headers.is_empty() {
+        return Ok(());
+    }
+
+    let mut finalized_headers_iter = finalized_headers.iter();
+    let mut last_slot = if storage.is_initialized()? {
+        finalized_headers[0].inner.slot - 1
+    } else {
+        let first = finalized_headers_iter.next().expect("checked");
+        storage.initialize_with(first.inner.slot, first.digest())?;
+        storage.put_tip_beacon_header_slot(first.inner.slot)?;
+        first.inner.slot
+    };
+
+    let mut mmr = storage.chain_root_mmr(last_slot)?;
+    for header in finalized_headers_iter {
+        last_slot = header.inner.slot;
+        mmr.push(header.digest()).map_err(StorageError::from)?;
+    }
+    mmr.commit().map_err(StorageError::from)?;
+
+    storage.put_tip_beacon_header_slot(last_slot)?;
+    Ok(())
+}
+
+pub fn align_native_and_onchain_updates<S, E>(
+    chain_id: &str,
+    header_updates: &Vec<EthUpdate>,
+    storage: &S,
+    onchain_packed_client: &PackedClient,
+) -> Result<(), Error>
+where
+    S: StorageReader<E> + StorageWriter<E> + StorageAsMMRStore<E>,
+    E: EthSpec,
+{
+    if header_updates.is_empty() {
+        return Err(Error::empty_upgraded_client_state());
+    }
+
+    // prepare minimal and maximal slots from onchain client
+    let onchain_minimal_slot = onchain_packed_client.minimal_slot().unpack();
+    let onchain_maximal_slot = onchain_packed_client.maximal_slot().unpack();
+
+    // check stored base slot is less than the onchain slot
+    if let Some(stored_base_slot) = storage.get_base_beacon_header_slot()? {
+        // unrecoverable condition
+        if stored_base_slot > onchain_minimal_slot {
+            return Err(Error::light_client_verification(
+                chain_id.to_owned(),
+                LightClientError::target_lower_than_trusted_state(
+                    into_height(onchain_minimal_slot),
+                    into_height(stored_base_slot),
+                ),
+            ));
+        }
+    }
+
+    let finalized_headers = into_cached_headers(header_updates);
+    let upcoming_start_slot = header_updates[0].finalized_header.slot;
+    let upcoming_last_slot = header_updates.last().unwrap().finalized_header.slot;
+
+    // check stored tip slot is less or greator than the onchain slot
+    if let Some(mut stored_tip_slot) = storage.get_tip_beacon_header_slot()? {
+        // recoverable condition: need to make native slots chase to onchain maximal slot
+        if stored_tip_slot < onchain_maximal_slot {
+            if upcoming_start_slot == stored_tip_slot + 1 {
+                commit_headers_into_mmr_storage(&finalized_headers, storage)?;
+                debug!(
+                    "headers from {} to {} are aligned to storage",
+                    upcoming_start_slot, upcoming_last_slot
+                );
+                stored_tip_slot = storage
+                    .get_tip_beacon_header_slot()?
+                    .expect("reacquire stored tip slot");
+            } else {
+                return Err(Error::light_client_verification(
+                    chain_id.to_owned(),
+                    LightClientError::missing_last_block_id(into_height(stored_tip_slot + 1)),
+                ));
+            }
+        }
+        // recoverable condition: need to make native tip slot chases to onchain maximal slot
+        if stored_tip_slot < onchain_maximal_slot {
+            return Err(Error::light_client_verification(
+                chain_id.to_owned(),
+                LightClientError::missing_last_block_id(into_height(stored_tip_slot + 1)),
+            ));
+        }
+    } else {
+        // recoverable condition: empty native slots need to be recovered according to the onchain slots
+        if upcoming_start_slot == onchain_minimal_slot {
+            commit_headers_into_mmr_storage(&finalized_headers, storage)?;
+            debug!(
+                "headers from {} to {} are aligned to storage (initialize)",
+                upcoming_start_slot, upcoming_last_slot
+            );
+        } else {
+            return Err(Error::light_client_verification(
+                chain_id.to_owned(),
+                LightClientError::missing_last_block_id(into_height(onchain_minimal_slot)),
+            ));
+        }
+        let stored_tip_slot = storage
+            .get_tip_beacon_header_slot()?
+            .expect("reaquire stored tip slot");
+        // recoverable condition: need to make native tip slot chases to onchain maximal slot
+        if stored_tip_slot < onchain_maximal_slot {
+            return Err(Error::light_client_verification(
+                chain_id.to_owned(),
+                LightClientError::missing_last_block_id(into_height(stored_tip_slot + 1)),
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn get_verified_packed_client_and_proof_update<S, E>(
+    chain_id: &String,
+    header_updates: &Vec<EthUpdate>,
+    storage: &S,
+    onchain_packed_client_opt: Option<PackedClient>,
+) -> Result<(Option<Slot>, PackedClient, PackedProofUpdate), Error>
+where
+    S: StorageReader<E> + StorageWriter<E> + StorageAsMMRStore<E>,
+    E: EthSpec,
+{
+    let mut prev_tip_slot = None;
+
+    if header_updates.is_empty() {
+        return Err(Error::empty_upgraded_client_state());
+    }
+
+    // make sure the upcoming headers' slot are continuous
+    let start_slot = header_updates[0].finalized_header.slot;
+    for (i, item) in header_updates.iter().enumerate() {
+        if item.finalized_header.slot != i as u64 + start_slot {
+            return Err(Error::send_tx("uncontinuous header slot".to_owned()));
+        }
+    }
+
+    // make sure the upcoming start slot is continuous with the onchain tip slot
+    if let Some(ref client) = onchain_packed_client_opt {
+        let onchain_tip_slot: u64 = client.maximal_slot().unpack();
+        if start_slot != onchain_tip_slot + 1 {
+            return Err(Error::light_client_verification(
+                chain_id.to_string(),
+                LightClientError::missing_last_block_id(into_height(onchain_tip_slot + 1)),
+            ));
+        }
+        prev_tip_slot = Some(onchain_tip_slot);
+    }
+
+    // make sure the upcoming start slot is continuous with the stored tip slot
+    if let Some(mut stored_tip_slot) = storage.get_tip_beacon_header_slot()? {
+        // trim exceesive slots from storage
+        if start_slot <= stored_tip_slot {
+            debug!(
+                "rollback stored tip slot from {} to {}",
+                stored_tip_slot, start_slot
+            );
+            storage.rollback_to(Some(start_slot - 1))?;
+            stored_tip_slot = storage
+                .get_tip_beacon_header_slot()?
+                .expect("reaquire stored tip slot");
+        }
+        assert_eq!(start_slot, stored_tip_slot + 1);
+    }
+
+    let finalized_headers = into_cached_headers(header_updates);
     let minimal_slot = storage.get_base_beacon_header_slot()?.unwrap_or(start_slot);
     let last_finalized_header = &finalized_headers[finalized_headers.len() - 1];
     let maximal_slot = last_finalized_header.inner.slot;
 
-    // Saves all header digests into storage for MMR.
-    {
-        let mut finalized_headers_iter = finalized_headers.iter();
+    // save all header digests into storage for MMR.
+    commit_headers_into_mmr_storage(&finalized_headers, storage)?;
 
-        let mut last_slot = if storage.is_initialized()? {
-            start_slot - 1
-        } else {
-            let first = finalized_headers_iter.next().expect("checked");
-            storage.initialize_with(first.inner.slot, first.digest())?;
-            storage.put_tip_beacon_header_slot(first.inner.slot)?;
-            first.inner.slot
-        };
-
-        let mut mmr = storage.chain_root_mmr(last_slot)?;
-
-        for header in finalized_headers_iter {
-            last_slot = header.inner.slot;
-            mmr.push(header.digest()).map_err(StorageError::from)?;
-        }
-        mmr.commit().map_err(StorageError::from)?;
-
-        storage.put_tip_beacon_header_slot(last_slot)?;
-    };
-
-    // Gets the new root and a proof for all new headers.
+    // get the new root and a proof for all new headers.
     let (packed_headers_mmr_root, packed_headers_mmr_proof) = {
         let positions = (start_slot..=maximal_slot)
             .into_iter()
@@ -141,7 +258,7 @@ where
         (headers_mmr_root, headers_mmr_proof)
     };
 
-    // Build the packed proof update.
+    // build the packed proof update.
     let packed_proof_update = {
         let updates_items = finalized_headers
             .iter()
@@ -161,7 +278,7 @@ where
             .build()
     };
 
-    // Invoke verification from core::Client on packed_proof_update
+    // invoke verification from core::Client on packed_proof_update
     let client = if let Some(client) = onchain_packed_client_opt {
         client
             .unpack()
@@ -175,16 +292,58 @@ where
     Ok((prev_tip_slot, client.pack(), packed_proof_update))
 }
 
+pub async fn wait_ckb_transaction_committed(
+    rpc: &Arc<RpcClient>,
+    hash: H256,
+    interval: Duration,
+    confirms: u8,
+) -> Result<(), Error> {
+    let mut block_number = 0u64;
+    loop {
+        tokio::time::sleep(interval).await;
+        let tx = rpc
+            .get_transaction(&hash)
+            .await?
+            .expect("wait transaction response");
+        if tx.tx_status.status == Status::Rejected {
+            return Err(Error::send_tx(format!(
+                "transaction {} had been rejected",
+                hex::encode(hash)
+            )));
+        }
+        if tx.tx_status.status != Status::Committed {
+            continue;
+        }
+        if block_number == 0 {
+            if let Some(block_hash) = tx.tx_status.block_hash {
+                let block = rpc.get_block(&block_hash).await?;
+                block_number = block.header.inner.number.into();
+            }
+        } else {
+            let tip = rpc.get_tip_header().await?;
+            let tip_number: u64 = tip.inner.number.into();
+            if tip_number >= block_number + confirms as u64 {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+    use super::align_native_and_onchain_updates;
     use super::get_verified_packed_client_and_proof_update;
     use super::EthHeader;
     use super::EthUpdate;
     use eth2_types::MainnetEthSpec;
     use eyre::Result;
-    use ibc_relayer_storage::Storage;
+    use ibc_relayer_storage::{prelude::StorageAsMMRStore, Storage};
     use std::fs;
     use tempfile::TempDir;
+
+    use crate::error::ErrorDetail::LightClientVerification;
+    use tendermint_light_client::errors::ErrorDetail::MissingLastBlockId;
 
     fn load_updates_from_file(path: &str) -> Result<Vec<EthUpdate>> {
         let headers_json = fs::read_to_string(path)?;
@@ -196,29 +355,71 @@ mod tests {
     }
 
     #[test]
-    fn test_get_verified_packed_client_and_proof_update() {
-        let path = TempDir::new().unwrap();
-        let storage: Storage<MainnetEthSpec> = Storage::new(path).unwrap();
+    fn test_verify_and_align_updates_with_empty_storage() {
         let chain_id = "chain_id".to_string();
-
-        // Testing updates for creation of light_client
         let updates_part_1 =
             load_updates_from_file("src/testdata/test_update_eth_client/headers-part-1.json")
                 .expect("part_1");
-        let (_, packed_client, _) =
-            get_verified_packed_client_and_proof_update(&chain_id, updates_part_1, &storage, None)
-                .expect("verify part_1");
-
-        // Testing updates for update of light_client
         let updates_part_2 =
             load_updates_from_file("src/testdata/test_update_eth_client/headers-part-2.json")
                 .expect("part_2");
-        get_verified_packed_client_and_proof_update(
+        let path = TempDir::new().unwrap();
+        let storage: Storage<MainnetEthSpec> = Storage::new(path).unwrap();
+
+        // generate onchain packed client for later use
+        let onchain_packed_client = {
+            let (_, onchain_packed_client, _) = get_verified_packed_client_and_proof_update(
+                &chain_id,
+                &updates_part_1,
+                &storage,
+                None,
+            )
+            .expect("verify part_1");
+
+            let (_, onchain_packed_client, _) = get_verified_packed_client_and_proof_update(
+                &chain_id,
+                &updates_part_2,
+                &storage,
+                Some(onchain_packed_client),
+            )
+            .expect("verify part_2");
+
+            onchain_packed_client
+        };
+
+        // empty storage
+        storage.rollback_to(None).expect("rollback");
+
+        // test first updates alignment
+        let result = align_native_and_onchain_updates(
             &chain_id,
-            updates_part_2,
+            &updates_part_1,
             &storage,
-            Some(packed_client),
+            &onchain_packed_client,
+        );
+        if let Err(error) = result {
+            match error.detail() {
+                LightClientVerification(error) => match &error.source {
+                    MissingLastBlockId(block) => {
+                        let missing_slot = updates_part_1.last().unwrap().finalized_header.slot + 1;
+                        assert_eq!(block.height, missing_slot.try_into().unwrap());
+                    }
+                    _ => panic!("unexpected error"),
+                },
+                _ => panic!("unexpected error"),
+            }
+        }
+
+        // test next updates alignment
+        align_native_and_onchain_updates(
+            &chain_id,
+            &updates_part_2,
+            &storage,
+            &onchain_packed_client,
         )
-        .expect("verify part_2");
+        .expect("align part_2");
     }
+
+    #[test]
+    fn test_verify_and_align_updates_with_exceesive_storage() {}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description
considered the below conditions about the mismatch between native mmr slots and on-chain slots:
1. native is empty, on-chain exists (recoverable)
2. base slot in native is greater than the base slot in on-chain (un-recoverable)
3. native and on-chain both exist, but the tip slot in native is less (or greater) than the tip slot in on-chain (recoverable)

leave 1 issue you guys need to consider:
https://www.lightclientdata.org/eth/v1/beacon/headers/5601247
https://www.lightclientdata.org/eth/v1/beacon/headers/5601248
https://www.lightclientdata.org/eth/v1/beacon/headers/5601249
 **slot 5601248 is unreachable!** 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
