### PR TITLE
feat: make sure there's no empty header in light-client creation mode

### DIFF
--- a/crates/relayer-types/src/clients/ics07_eth/types.rs
+++ b/crates/relayer-types/src/clients/ics07_eth/types.rs
@@ -103,6 +103,15 @@ impl Update {
             ..Default::default()
         }
     }
+
+    pub fn is_finalized_empty(&self) -> bool {
+        let header = &self.finalized_header;
+        header.slot > 0
+            && header.proposer_index == 0
+            && header.parent_root == Default::default()
+            && header.state_root == Default::default()
+            && header.body_root == Default::default()
+    }
 }
 
 impl From<&Update> for GenericUpdate {

--- a/crates/relayer/src/chain/ckb.rs
+++ b/crates/relayer/src/chain/ckb.rs
@@ -115,21 +115,19 @@ impl CkbChain {
 
     pub(crate) fn update_eth_client(
         &mut self,
-        header_updates: Vec<EthUpdate>,
+        mut header_updates: Vec<EthUpdate>,
     ) -> Result<Vec<IbcEventWithHeight>, Error> {
         let chain_id = self.id().to_string();
         let onchain_packed_client_opt = self.rt.block_on(self.rpc_client.fetch_packed_client(
             &self.config.lightclient_contract_typeargs,
             &self.config.id.to_string(),
         ))?;
-        if let Some(ref onchain_packed_client) = onchain_packed_client_opt {
-            utils::align_native_and_onchain_updates(
-                &chain_id,
-                &header_updates,
-                &self.storage,
-                onchain_packed_client,
-            )?;
-        }
+        utils::align_native_and_onchain_updates(
+            &chain_id,
+            &mut header_updates,
+            &self.storage,
+            onchain_packed_client_opt.as_ref(),
+        )?;
         let (prev_slot_opt, packed_client, packed_proof_update) =
             utils::get_verified_packed_client_and_proof_update(
                 &chain_id,

--- a/crates/relayer/src/chain/ckb/assembler.rs
+++ b/crates/relayer/src/chain/ckb/assembler.rs
@@ -91,7 +91,7 @@ pub trait TxAssembler: CellSearcher + TxCompleter {
         contract_typeid_args: &H256,
         client_id: &String,
     ) -> Result<(TransactionView, Vec<packed::CellOutput>), Error> {
-        // Find celldeps by searching live cells according typeid_args
+        // find celldeps by searching live cells according typeid_args
         let contract_typescript = make_typeid_script(contract_typeid_args.as_bytes().to_vec());
         let contract_cell_dep = {
             let contract_cell =
@@ -109,18 +109,18 @@ pub trait TxAssembler: CellSearcher + TxCompleter {
                 .dep_type(DepType::Code.into())
                 .build()
         };
-        // Search light-client cell by lightclient contract type_id hash
+        // search light-client cell by lightclient contract type_id hash
         let contract_typehash = contract_typescript.calc_script_hash();
         let lightclient_cell_opt = self
             .search_cell_by_typescript(&contract_typehash, &client_id.as_bytes().to_vec())
             .await?;
-        // Build Lightclient Lockscript and Typescript
+        // build Lightclient Lockscript and Typescript
         let pubkey_hash = address.payload().args();
         let lightclient_lock =
             make_lightclient_script(mock_lockscript.calc_script_hash(), pubkey_hash.to_vec());
         let lightclient_type =
             make_lightclient_script(contract_typehash, client_id.clone().into_bytes());
-        // Assemble Lightclient output cell
+        // assemble Lightclient output cell
         let output_data = packed_client.as_slice().pack();
         let output_cell = packed::CellOutput::new_builder()
             .lock(lightclient_lock)
@@ -135,7 +135,7 @@ pub trait TxAssembler: CellSearcher + TxCompleter {
             inputs_capacity += Unpack::<u64>::unpack(&lightclient_cell.output.capacity());
             inputs_cell_as_output.push(lightclient_cell.output);
         }
-        // Assemble Lightclient witness
+        // assemble Lightclient witness
         let witness = {
             let input_type_args = packed::BytesOpt::new_builder()
                 .set(Some(packed_proof_update.as_slice().pack()))
@@ -145,7 +145,7 @@ pub trait TxAssembler: CellSearcher + TxCompleter {
                 .build();
             witness_args.as_bytes()
         };
-        // Assemble transaction
+        // assemble transaction
         let tx = TransactionView::new_advanced_builder()
             .inputs(inputs_cell)
             .output(output_cell)
@@ -158,7 +158,7 @@ pub trait TxAssembler: CellSearcher + TxCompleter {
         let (tx, mut new_inputs) = self
             .complete_tx_with_secp256k1_change(tx, address, inputs_capacity, fee_rate)
             .await?;
-        // Collect input cells to support signing process (calculating input group)
+        // collect input cells to support signing process (calculating input group)
         inputs_cell_as_output.append(&mut new_inputs);
         Ok((tx, inputs_cell_as_output))
     }

--- a/crates/relayer/src/chain/eth/event/monitor.rs
+++ b/crates/relayer/src/chain/eth/event/monitor.rs
@@ -85,7 +85,7 @@ impl EthEventMonitor {
             if !headers.is_empty() {
                 let start_slot = headers.first().unwrap().slot;
                 let end_slot = headers.last().unwrap().slot;
-                info!("receive new headers from {} to {}", start_slot, end_slot);
+                info!("receive new headers [{}, {}]", start_slot, end_slot);
                 let events = headers
                     .into_iter()
                     .map(|header| {

--- a/crates/relayer/tests/config/fixtures/relayer_conf_example.toml
+++ b/crates/relayer/tests/config/fixtures/relayer_conf_example.toml
@@ -65,7 +65,7 @@ id = 'ibc-eth-0'
 genesis_time = 1606824023
 genesis_root = "0x4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95"
 websocket_addr = 'wss://eth-mainnet.g.alchemy.com/v2/bP31lpybtbwJkUWRp850Qds3LV86d1Kv'
-initial_checkpoint = "0xe4d168932628537930f29f3022dc3b2cd51e77b25b86ea635c7449c41cfd0779"
+initial_checkpoint = "0xa179cbd497b112acb057039601a75e2daafae994aa5f01d6e1a1d6f85e07a8ef"
 # key_name = 'connections'
 key_name = 'relayer_eth_wallet'
 rpc_addr = 'https://www.lightclientdata.org'
@@ -80,7 +80,7 @@ bellatrix = { epoch = 144896, fork_version = "0x02000000" }
 id = 'ibc-ckb-0'
 ckb_rpc = "https://testnet.ckbapp.dev"
 ckb_indexer_rpc = "https://testnet.ckbapp.dev"
-lightclient_contract_typeargs = "0x491aa1c22c2b1beb4c82c00e694ff2c514adf58dce4cca8bed5cc601d6a7a9d7"
+lightclient_contract_typeargs = "0xb7fcfa4ad253ddd60481bdd35331a634ff985fdb3b3fab4e1066cf97faf40315"
 lightclient_lock_typeargs = "0xd6eb3b34c445a1fe914f4e22c13380cf3b6102d9c2b949a8544d1a2f72a8b6c7"
 key_name = "relayer_ckb_wallet"
 data_dir = "./ckb_mmr_storage"


### PR DESCRIPTION

bug: make default header with specified slot while getting error from get_header rpc

chore: adjust log-printing in the Forcerelay spawning task

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description
@yangby-cryptape please make sure the `get_header` fallback logic is proper, and after merging your previous PR which can be enabled even if headers are discontinuous, the header-aligner will remove empty headers from the left side in the `update_headers`

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
