### PR TITLE
feat: use tip valid header root to instead of tip header root in client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,13 +2088,14 @@ dependencies = [
 [[package]]
 name = "eth_light_client_in_ckb-verification"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/yangby-cryptape/eth-light-client-in-ckb?rev=779dab1#779dab1b3a70ec0af064620f312eb90daa22ab7f"
+source = "git+https://github.com/yangby-cryptape/eth-light-client-in-ckb?rev=707d7f6#707d7f656fd253152da029955aa7d73ff9b9c5e3"
 dependencies = [
  "ckb-merkle-mountain-range",
  "eth2_hashing",
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
+ "log",
  "merkle_proof",
  "molecule",
  "rlp",

--- a/crates/relayer-storage/Cargo.toml
+++ b/crates/relayer-storage/Cargo.toml
@@ -15,4 +15,4 @@ description  = "The storage part of SynapseWeb3 IBC Relayer"
 thiserror = "1.0.37"
 rocksdb = { package = "ckb-rocksdb", version ="=0.19.0", default-features = false, features = ["snappy"] }
 eth2_types = { git = "https://github.com/yangby-cryptape/lighthouse", rev = "62dc610", package = "types" }
-eth_light_client_in_ckb-verification = { version = "0.1.0-alpha.0", git = "https://github.com/yangby-cryptape/eth-light-client-in-ckb", rev = "779dab1" }
+eth_light_client_in_ckb-verification = { version = "0.1.0-alpha.0", git = "https://github.com/yangby-cryptape/eth-light-client-in-ckb", rev = "707d7f6" }

--- a/crates/relayer-types/src/clients/ics07_eth/header.rs
+++ b/crates/relayer-types/src/clients/ics07_eth/header.rs
@@ -28,9 +28,9 @@ impl Header {
     pub fn is_empty(&self) -> bool {
         self.slot > 0
             && self.proposer_index == 0
-            && self.parent_root == Default::default()
-            && self.state_root == Default::default()
-            && self.body_root == Default::default()
+            && self.parent_root.is_zero()
+            && self.state_root.is_zero()
+            && self.body_root.is_zero()
     }
 }
 

--- a/crates/relayer/Cargo.toml
+++ b/crates/relayer/Cargo.toml
@@ -30,7 +30,7 @@ eth2_types       = { git = "https://github.com/yangby-cryptape/lighthouse", rev 
 tree_hash_derive = { git = "https://github.com/yangby-cryptape/lighthouse", rev = "62dc610" }
 tree_hash        = { git = "https://github.com/yangby-cryptape/lighthouse", rev = "62dc610" }
 
-eth_light_client_in_ckb-verification = { version = "0.1.0-alpha.0", git = "https://github.com/yangby-cryptape/eth-light-client-in-ckb", rev = "779dab1" }
+eth_light_client_in_ckb-verification = { version = "0.1.0-alpha.0", git = "https://github.com/yangby-cryptape/eth-light-client-in-ckb", rev = "707d7f6" }
 
 subtle-encoding = "0.5"
 humantime-serde = "1.1.1"

--- a/crates/relayer/src/chain/ckb.rs
+++ b/crates/relayer/src/chain/ckb.rs
@@ -1,6 +1,5 @@
 use ckb_jsonrpc_types::{OutputsValidator, TransactionView as JsonTx};
 use ckb_sdk::{Address, AddressPayload, NetworkType};
-use ckb_types::prelude::Entity;
 use eth2_types::MainnetEthSpec;
 use eth_light_client_in_ckb_verification::types::prelude::Unpack;
 use ibc_relayer_storage::prelude::{StorageAsMMRStore as _, StorageReader as _};
@@ -250,13 +249,8 @@ impl CkbChain {
         ))?;
         let mut status_log = String::new();
         if let Some(packed_client) = onchain_packed_client_opt {
-            let minimal_slot: u64 = packed_client.minimal_slot().unpack();
-            let maximal_slot: u64 = packed_client.maximal_slot().unpack();
-            let tip_header_digest = packed_client.tip_header_root();
-            status_log += &format!(
-                "on-chain status: [{minimal_slot}, {maximal_slot}] tip = 0x{}, ",
-                hex::encode(tip_header_digest.as_slice())
-            );
+            let client = packed_client.unpack();
+            status_log += &format!("on-chain status: {client}, ");
         } else {
             status_log += "on-chain status: NONE, ";
         }

--- a/crates/relayer/src/chain/ckb/utils.rs
+++ b/crates/relayer/src/chain/ckb/utils.rs
@@ -298,10 +298,10 @@ where
         client
             .unpack()
             .try_apply_packed_proof_update(packed_proof_update.as_reader())
-            .map_err(|e| Error::send_tx(format!("failed to update header, error = {}", e as u8)))?
+            .map_err(|e| Error::send_tx(format!("failed to update header, error = {}", e as i8)))?
     } else {
         EthLcClient::new_from_packed_proof_update(packed_proof_update.as_reader())
-            .map_err(|e| Error::send_tx(format!("failed to create header, error = {}", e as u8)))?
+            .map_err(|e| Error::send_tx(format!("failed to create header, error = {}", e as i8)))?
     };
 
     Ok((prev_tip_slot, client.pack(), packed_proof_update))
@@ -322,8 +322,7 @@ pub async fn wait_ckb_transaction_committed(
             .expect("wait transaction response");
         if tx.tx_status.status == Status::Rejected {
             return Err(Error::send_tx(format!(
-                "transaction {} had been rejected",
-                hex::encode(hash)
+                "transaction {hash:#x} had been rejected"
             )));
         }
         if tx.tx_status.status != Status::Committed {


### PR DESCRIPTION
Upgrade to latest commit for the following features:
- Use tip valid header root to instead of tip header root in client.
- Add log outputs when enabled the `std` feature.
- Customize error code for errors (represent as i8).

References:
- [Details of the Changes](https://github.com/yangby-cryptape/eth-light-client-in-ckb/compare/779dab1...707d7f6)
- [The IBC Contracts in the Correspond Version](https://github.com/yangby-cryptape/ibc-ckb-contracts/tree/e6bb3c7)