### PR TITLE
feat: make create_eth_client() work for ckb chain with initial slot f…

### DIFF
--- a/crates/relayer/src/chain/ckb/utils.rs
+++ b/crates/relayer/src/chain/ckb/utils.rs
@@ -23,7 +23,7 @@ use crate::error::Error;
 
 use super::rpc_client::RpcClient;
 
-fn into_height(slot: u64) -> tendermint::block::Height {
+pub fn into_height(slot: u64) -> tendermint::block::Height {
     slot.try_into().expect("slot too big")
 }
 
@@ -191,7 +191,7 @@ pub fn get_verified_packed_client_and_proof_update<S, E>(
     chain_id: &String,
     header_updates: &Vec<EthUpdate>,
     storage: &S,
-    onchain_packed_client_opt: Option<PackedClient>,
+    onchain_packed_client_opt: Option<&PackedClient>,
 ) -> Result<(Option<Slot>, PackedClient, PackedProofUpdate), Error>
 where
     S: StorageReader<E> + StorageWriter<E> + StorageAsMMRStore<E>,
@@ -212,7 +212,7 @@ where
     }
 
     // make sure the upcoming start slot is continuous with the onchain tip slot
-    if let Some(ref client) = onchain_packed_client_opt {
+    if let Some(client) = onchain_packed_client_opt {
         let onchain_tip_slot: u64 = client.maximal_slot().unpack();
         if start_slot != onchain_tip_slot + 1 {
             return Err(Error::light_client_verification(
@@ -405,7 +405,7 @@ mod tests {
                 &chain_id,
                 &updates_part_2,
                 &storage,
-                Some(onchain_packed_client),
+                Some(&onchain_packed_client),
             )
             .expect("verify part_2");
 


### PR DESCRIPTION
…rom configured checkpoint

chore: check ckb key config in boostrap stage

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description
there's a problem with a broken light-client cell which if it happens should make a new one starting from the same base slot, so I complete the `create_eth_client()` function for the CKB ChainEndpoint and make use of it.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
