### PR TITLE
build: change some git urls of dependencies since those repos are transfered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,26 +498,14 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
-dependencies = [
- "funty 1.1.0",
- "radium 0.6.2",
- "tap",
- "wyz 0.2.0",
-]
-
-[[package]]
-name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
- "funty 2.0.0",
+ "funty",
  "radium 0.7.0",
  "tap",
- "wyz 0.5.1",
+ "wyz",
 ]
 
 [[package]]
@@ -587,36 +575,18 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
  "blst",
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "eth2_serde_utils 0.1.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "eth2_ssz 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "ethereum-types 0.14.1",
+ "eth2_hashing",
+ "eth2_serde_utils",
+ "eth2_ssz",
+ "ethereum-types",
  "hex",
  "rand 0.7.3",
  "serde",
  "serde_derive",
- "tree_hash 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "zeroize",
-]
-
-[[package]]
-name = "bls"
-version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
-dependencies = [
- "blst",
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "eth2_serde_utils 0.1.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "eth2_ssz 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "ethereum-types 0.12.1",
- "hex",
- "rand 0.7.3",
- "serde",
- "serde_derive",
- "tree_hash 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
+ "tree_hash",
  "zeroize",
 ]
 
@@ -744,29 +714,15 @@ dependencies = [
 [[package]]
 name = "cached_tree_hash"
 version = "0.1.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "eth2_ssz 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "eth2_ssz_derive 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "eth2_ssz_types 0.2.2 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "ethereum-types 0.14.1",
+ "eth2_hashing",
+ "eth2_ssz",
+ "eth2_ssz_derive",
+ "eth2_ssz_types",
+ "ethereum-types",
  "smallvec",
- "tree_hash 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
-]
-
-[[package]]
-name = "cached_tree_hash"
-version = "0.1.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
-dependencies = [
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "eth2_ssz 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "eth2_ssz_derive 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "eth2_ssz_types 0.2.2 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "ethereum-types 0.12.1",
- "smallvec",
- "tree_hash 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
+ "tree_hash",
 ]
 
 [[package]]
@@ -1329,26 +1285,12 @@ dependencies = [
 [[package]]
 name = "compare_fields"
 version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
-
-[[package]]
-name = "compare_fields"
-version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 
 [[package]]
 name = "compare_fields_derive"
 version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "compare_fields_derive"
-version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
  "quote",
  "syn",
@@ -2059,18 +2001,7 @@ dependencies = [
 [[package]]
 name = "eth2_hashing"
 version = "0.3.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
-dependencies = [
- "cpufeatures",
- "lazy_static",
- "ring",
- "sha2 0.10.6",
-]
-
-[[package]]
-name = "eth2_hashing"
-version = "0.3.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
  "cpufeatures",
  "lazy_static",
@@ -2081,25 +2012,10 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
- "bls 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "hex",
- "lazy_static",
- "num-bigint",
- "serde",
- "serde_derive",
- "serde_yaml 0.8.26",
-]
-
-[[package]]
-name = "eth2_interop_keypairs"
-version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
-dependencies = [
- "bls 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
+ "bls",
+ "eth2_hashing",
  "hex",
  "lazy_static",
  "num-bigint",
@@ -2111,21 +2027,9 @@ dependencies = [
 [[package]]
 name = "eth2_serde_utils"
 version = "0.1.1"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
- "ethereum-types 0.14.1",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "eth2_serde_utils"
-version = "0.1.1"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
-dependencies = [
- "ethereum-types 0.12.1",
+ "ethereum-types",
  "hex",
  "serde",
  "serde_derive",
@@ -2135,19 +2039,9 @@ dependencies = [
 [[package]]
 name = "eth2_ssz"
 version = "0.4.1"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
- "ethereum-types 0.14.1",
- "itertools",
- "smallvec",
-]
-
-[[package]]
-name = "eth2_ssz"
-version = "0.4.1"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
-dependencies = [
- "ethereum-types 0.12.1",
+ "ethereum-types",
  "itertools",
  "smallvec",
 ]
@@ -2155,18 +2049,7 @@ dependencies = [
 [[package]]
 name = "eth2_ssz_derive"
 version = "0.3.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "eth2_ssz_derive"
-version = "0.3.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2177,73 +2060,37 @@ dependencies = [
 [[package]]
 name = "eth2_ssz_types"
 version = "0.2.2"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
  "arbitrary",
  "derivative",
- "eth2_serde_utils 0.1.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "eth2_ssz 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
+ "eth2_serde_utils",
+ "eth2_ssz",
  "serde",
  "serde_derive",
  "smallvec",
- "tree_hash 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "typenum",
-]
-
-[[package]]
-name = "eth2_ssz_types"
-version = "0.2.2"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
-dependencies = [
- "arbitrary",
- "derivative",
- "eth2_serde_utils 0.1.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "eth2_ssz 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "serde",
- "serde_derive",
- "smallvec",
- "tree_hash 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
+ "tree_hash",
  "typenum",
 ]
 
 [[package]]
 name = "eth_light_client_in_ckb-verification"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/yangby-cryptape/eth-light-client-in-ckb?rev=5ba3e1e#5ba3e1ed87f1b378b8b4c5cfc96203d8f337d4ab"
+source = "git+https://github.com/synapseweb3/eth-light-client-in-ckb?rev=e94ec1a#e94ec1ab13667eb1d3a1fba09abf495198254147"
 dependencies = [
  "ckb-merkle-mountain-range",
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "eth2_ssz 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "eth2_ssz_derive 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "eth2_ssz_types 0.2.2 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
+ "eth2_hashing",
+ "eth2_ssz",
+ "eth2_ssz_derive",
+ "eth2_ssz_types",
  "log",
- "merkle_proof 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
+ "merkle_proof",
  "molecule",
  "rlp",
  "tiny-keccak",
- "tree_hash 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "tree_hash_derive 0.4.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "types 0.2.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
-]
-
-[[package]]
-name = "eth_light_client_in_ckb-verification"
-version = "0.1.0-alpha.0"
-source = "git+https://github.com/yangby-cryptape/eth-light-client-in-ckb?rev=707d7f6#707d7f656fd253152da029955aa7d73ff9b9c5e3"
-dependencies = [
- "ckb-merkle-mountain-range",
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "eth2_ssz 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "eth2_ssz_derive 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "eth2_ssz_types 0.2.2 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "log",
- "merkle_proof 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "molecule",
- "rlp",
- "tiny-keccak",
- "tree_hash 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "tree_hash_derive 0.4.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "types 0.2.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
+ "tree_hash",
+ "tree_hash_derive",
+ "types",
 ]
 
 [[package]]
@@ -2252,7 +2099,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
 dependencies = [
- "ethereum-types 0.14.1",
+ "ethereum-types",
  "hex",
  "once_cell",
  "regex",
@@ -2265,44 +2112,17 @@ dependencies = [
 
 [[package]]
 name = "ethbloom"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
-dependencies = [
- "crunchy",
- "fixed-hash 0.7.0",
- "impl-rlp",
- "impl-serde 0.3.2",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethbloom"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
+ "fixed-hash",
+ "impl-codec",
  "impl-rlp",
- "impl-serde 0.4.0",
+ "impl-serde",
  "scale-info",
  "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
-dependencies = [
- "ethbloom 0.11.1",
- "fixed-hash 0.7.0",
- "impl-rlp",
- "impl-serde 0.3.2",
- "primitive-types 0.10.1",
- "uint",
 ]
 
 [[package]]
@@ -2311,12 +2131,12 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
- "ethbloom 0.13.0",
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
+ "ethbloom",
+ "fixed-hash",
+ "impl-codec",
  "impl-rlp",
- "impl-serde 0.4.0",
- "primitive-types 0.12.1",
+ "impl-serde",
+ "primitive-types",
  "scale-info",
  "uint",
 ]
@@ -2646,18 +2466,6 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "byteorder",
- "rand 0.8.5",
- "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
-name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
@@ -2708,7 +2516,7 @@ dependencies = [
  "ckb-jsonrpc-types",
  "ckb-sdk",
  "ckb-types",
- "eth_light_client_in_ckb-verification 0.1.0-alpha.0 (git+https://github.com/yangby-cryptape/eth-light-client-in-ckb?rev=707d7f6)",
+ "eth_light_client_in_ckb-verification",
  "hex",
 ]
 
@@ -2786,12 +2594,6 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "funty"
@@ -3459,7 +3261,7 @@ dependencies = [
  "ed25519-dalek",
  "ed25519-dalek-bip32",
  "env_logger 0.10.0",
- "eth_light_client_in_ckb-verification 0.1.0-alpha.0 (git+https://github.com/yangby-cryptape/eth-light-client-in-ckb?rev=5ba3e1e)",
+ "eth_light_client_in_ckb-verification",
  "ethers",
  "ethers-contract",
  "ethers-providers",
@@ -3514,9 +3316,9 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
- "tree_hash 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "tree_hash_derive 0.4.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "types 0.2.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
+ "tree_hash",
+ "tree_hash_derive",
+ "types",
  "uuid 1.2.2",
 ]
 
@@ -3580,23 +3382,23 @@ name = "ibc-relayer-storage"
 version = "0.1.0"
 dependencies = [
  "ckb-rocksdb",
- "eth_light_client_in_ckb-verification 0.1.0-alpha.0 (git+https://github.com/yangby-cryptape/eth-light-client-in-ckb?rev=5ba3e1e)",
+ "eth_light_client_in_ckb-verification",
  "thiserror",
- "types 0.2.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
+ "types",
 ]
 
 [[package]]
 name = "ibc-relayer-types"
 version = "0.21.0"
 dependencies = [
- "bls 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
+ "bls",
  "bytes",
  "derive_more",
  "dyn-clone",
  "env_logger 0.10.0",
  "erased-serde",
- "eth2_ssz_types 0.2.2 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "ethereum-types 0.14.1",
+ "eth2_ssz_types",
+ "ethereum-types",
  "flex-error",
  "hex",
  "ibc-proto",
@@ -3604,7 +3406,7 @@ dependencies = [
  "itertools",
  "modelator",
  "num-rational",
- "primitive-types 0.12.1",
+ "primitive-types",
  "prost",
  "safe-regex",
  "serde",
@@ -3621,8 +3423,8 @@ dependencies = [
  "time 0.3.17",
  "tracing",
  "tracing-subscriber",
- "tree_hash 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "tree_hash_derive 0.4.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
+ "tree_hash",
+ "tree_hash_derive",
  "uint",
 ]
 
@@ -3709,20 +3511,11 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
-dependencies = [
- "parity-scale-codec 2.3.1",
-]
-
-[[package]]
-name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
- "parity-scale-codec 3.2.1",
+ "parity-scale-codec",
 ]
 
 [[package]]
@@ -3732,15 +3525,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
 dependencies = [
  "rlp",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3856,15 +3640,7 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
-dependencies = [
- "bytes",
-]
-
-[[package]]
-name = "int_to_bytes"
-version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
  "bytes",
 ]
@@ -4248,23 +4024,12 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "ethereum-types 0.14.1",
+ "eth2_hashing",
+ "ethereum-types",
  "lazy_static",
- "safe_arith 0.1.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
-]
-
-[[package]]
-name = "merkle_proof"
-version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
-dependencies = [
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "ethereum-types 0.12.1",
- "lazy_static",
- "safe_arith 0.1.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
+ "safe_arith",
 ]
 
 [[package]]
@@ -4706,7 +4471,7 @@ dependencies = [
  "arrayvec",
  "auto_impl 1.0.1",
  "bytes",
- "ethereum-types 0.14.1",
+ "ethereum-types",
  "open-fastrlp-derive",
 ]
 
@@ -4864,20 +4629,6 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
-dependencies = [
- "arrayvec",
- "bitvec 0.20.4",
- "byte-slice-cast",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive 2.3.1",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "366e44391a8af4cfd6002ef6ba072bae071a96aafca98d7d448a34c5dca38b6a"
@@ -4886,20 +4637,8 @@ dependencies = [
  "bitvec 1.0.1",
  "byte-slice-cast",
  "impl-trait-for-tuples",
- "parity-scale-codec-derive 3.1.3",
+ "parity-scale-codec-derive",
  "serde",
-]
-
-[[package]]
-name = "parity-scale-codec-derive"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -5260,27 +4999,14 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "primitive-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
-dependencies = [
- "fixed-hash 0.7.0",
- "impl-codec 0.5.1",
- "impl-rlp",
- "impl-serde 0.3.2",
- "uint",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
+ "fixed-hash",
+ "impl-codec",
  "impl-rlp",
- "impl-serde 0.4.0",
+ "impl-serde",
  "scale-info",
  "uint",
 ]
@@ -5450,12 +5176,6 @@ name = "radium"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
-
-[[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "radium"
@@ -6023,12 +5743,7 @@ dependencies = [
 [[package]]
 name = "safe_arith"
 version = "0.1.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
-
-[[package]]
-name = "safe_arith"
-version = "0.1.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 
 [[package]]
 name = "safemem"
@@ -6062,7 +5777,7 @@ checksum = "88d8a765117b237ef233705cc2cc4c6a27fccd46eea6ef0c8c6dae5f3ef407f8"
 dependencies = [
  "cfg-if 1.0.0",
  "derive_more",
- "parity-scale-codec 3.2.1",
+ "parity-scale-codec",
  "scale-info-derive",
 ]
 
@@ -6719,19 +6434,10 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "ethereum-types 0.14.1",
-]
-
-[[package]]
-name = "swap_or_not_shuffle"
-version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
-dependencies = [
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "ethereum-types 0.12.1",
+ "eth2_hashing",
+ "ethereum-types",
 ]
 
 [[package]]
@@ -7000,16 +6706,7 @@ dependencies = [
 [[package]]
 name = "test_random_derive"
 version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "test_random_derive"
-version = "0.2.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
  "quote",
  "syn",
@@ -7481,37 +7178,17 @@ dependencies = [
 [[package]]
 name = "tree_hash"
 version = "0.4.1"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "ethereum-types 0.14.1",
- "smallvec",
-]
-
-[[package]]
-name = "tree_hash"
-version = "0.4.1"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
-dependencies = [
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "ethereum-types 0.12.1",
+ "eth2_hashing",
+ "ethereum-types",
  "smallvec",
 ]
 
 [[package]]
 name = "tree_hash_derive"
 version = "0.4.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
-dependencies = [
- "darling",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tree_hash_derive"
-version = "0.4.0"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
  "darling",
  "quote",
@@ -7569,27 +7246,27 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
+source = "git+https://github.com/synapseweb3/lighthouse?rev=307ade9#307ade97f19792c6ee6b93fdfaa392c3d38ea110"
 dependencies = [
- "bls 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "cached_tree_hash 0.1.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "compare_fields 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "compare_fields_derive 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
+ "bls",
+ "cached_tree_hash",
+ "compare_fields",
+ "compare_fields_derive",
  "derivative",
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "eth2_interop_keypairs 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "eth2_serde_utils 0.1.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "eth2_ssz 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "eth2_ssz_derive 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "eth2_ssz_types 0.2.2 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "ethereum-types 0.14.1",
+ "eth2_hashing",
+ "eth2_interop_keypairs",
+ "eth2_serde_utils",
+ "eth2_ssz",
+ "eth2_ssz_derive",
+ "eth2_ssz_types",
+ "ethereum-types",
  "hex",
- "int_to_bytes 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
+ "int_to_bytes",
  "itertools",
  "lazy_static",
  "log",
  "maplit",
- "merkle_proof 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
+ "merkle_proof",
  "metastruct",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -7597,7 +7274,7 @@ dependencies = [
  "rayon",
  "regex",
  "rusqlite",
- "safe_arith 0.1.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
+ "safe_arith",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7606,57 +7283,11 @@ dependencies = [
  "slog",
  "smallvec",
  "superstruct",
- "swap_or_not_shuffle 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
+ "swap_or_not_shuffle",
  "tempfile",
- "test_random_derive 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "tree_hash 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
- "tree_hash_derive 0.4.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=307ade9)",
-]
-
-[[package]]
-name = "types"
-version = "0.2.1"
-source = "git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610#62dc610037abf9b7cb08fc9c9bb05528ebedf9cf"
-dependencies = [
- "bls 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "cached_tree_hash 0.1.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "compare_fields 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "compare_fields_derive 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "derivative",
- "eth2_hashing 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "eth2_interop_keypairs 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "eth2_serde_utils 0.1.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "eth2_ssz 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "eth2_ssz_derive 0.3.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "eth2_ssz_types 0.2.2 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "ethereum-types 0.12.1",
- "hex",
- "int_to_bytes 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "itertools",
- "lazy_static",
- "log",
- "maplit",
- "merkle_proof 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "rand_xorshift",
- "rayon",
- "regex",
- "rusqlite",
- "safe_arith 0.1.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with",
- "serde_yaml 0.8.26",
- "slog",
- "smallvec",
- "superstruct",
- "swap_or_not_shuffle 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "tempfile",
- "test_random_derive 0.2.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "tree_hash 0.4.1 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
- "tree_hash_derive 0.4.0 (git+https://github.com/yangby-cryptape/lighthouse?rev=62dc610)",
+ "test_random_derive",
+ "tree_hash",
+ "tree_hash_derive",
 ]
 
 [[package]]
@@ -8205,12 +7836,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "wyz"

--- a/crates/relayer-storage/Cargo.toml
+++ b/crates/relayer-storage/Cargo.toml
@@ -14,5 +14,5 @@ description  = "The storage part of SynapseWeb3 IBC Relayer"
 [dependencies]
 thiserror = "1.0.37"
 rocksdb = { package = "ckb-rocksdb", version ="=0.19.0", default-features = false, features = ["snappy"] }
-eth2_types = { git = "https://github.com/yangby-cryptape/lighthouse", rev = "307ade9", package = "types" }
-eth_light_client_in_ckb-verification = { version = "0.1.0-alpha.0", git = "https://github.com/yangby-cryptape/eth-light-client-in-ckb", rev = "5ba3e1e" }
+eth2_types = { git = "https://github.com/synapseweb3/lighthouse", rev = "307ade9", package = "types" }
+eth_light_client_in_ckb-verification = { version = "0.1.0-alpha.0", git = "https://github.com/synapseweb3/eth-light-client-in-ckb", rev = "e94ec1a" }

--- a/crates/relayer-types/Cargo.toml
+++ b/crates/relayer-types/Cargo.toml
@@ -45,10 +45,10 @@ itertools = { version = "0.10.3", default-features = false, features = ["use_all
 primitive-types = { version = "0.12.1", default-features = false, features = ["serde_no_std"] }
 dyn-clone = "1.0.8"
 num-rational = "0.4.1"
-eth2_ssz_types   = { git = "https://github.com/yangby-cryptape/lighthouse", rev = "307ade9" }
-bls              = { git = "https://github.com/yangby-cryptape/lighthouse", rev = "307ade9" }
-tree_hash        = { git = "https://github.com/yangby-cryptape/lighthouse", rev = "307ade9" }
-tree_hash_derive = { git = "https://github.com/yangby-cryptape/lighthouse", rev = "307ade9" }
+eth2_ssz_types   = { git = "https://github.com/synapseweb3/lighthouse", rev = "307ade9" }
+bls              = { git = "https://github.com/synapseweb3/lighthouse", rev = "307ade9" }
+tree_hash        = { git = "https://github.com/synapseweb3/lighthouse", rev = "307ade9" }
+tree_hash_derive = { git = "https://github.com/synapseweb3/lighthouse", rev = "307ade9" }
 thiserror = "1.0"
 ethereum-types = "0.14.1"
 hex = "0.4"

--- a/crates/relayer/Cargo.toml
+++ b/crates/relayer/Cargo.toml
@@ -26,11 +26,11 @@ ibc-telemetry       = { version = "0.21.0", path = "../telemetry", optional = tr
 ibc-relayer-types   = { version = "0.21.0", path = "../relayer-types", features = ["mocks"] }
 ibc-relayer-storage = { version = "0.1.0",  path = "../relayer-storage" }
 
-eth2_types       = { git = "https://github.com/yangby-cryptape/lighthouse", rev = "307ade9", package = "types" }
-tree_hash_derive = { git = "https://github.com/yangby-cryptape/lighthouse", rev = "307ade9" }
-tree_hash        = { git = "https://github.com/yangby-cryptape/lighthouse", rev = "307ade9" }
+eth2_types       = { git = "https://github.com/synapseweb3/lighthouse", rev = "307ade9", package = "types" }
+tree_hash_derive = { git = "https://github.com/synapseweb3/lighthouse", rev = "307ade9" }
+tree_hash        = { git = "https://github.com/synapseweb3/lighthouse", rev = "307ade9" }
 
-eth_light_client_in_ckb-verification = { version = "0.1.0-alpha.0", git = "https://github.com/yangby-cryptape/eth-light-client-in-ckb", rev = "5ba3e1e" }
+eth_light_client_in_ckb-verification = { version = "0.1.0-alpha.0", git = "https://github.com/synapseweb3/eth-light-client-in-ckb", rev = "e94ec1a" }
 
 subtle-encoding = "0.5"
 humantime-serde = "1.1.1"

--- a/tools/forcerelay-test/Cargo.toml
+++ b/tools/forcerelay-test/Cargo.toml
@@ -9,4 +9,4 @@ ckb-jsonrpc-types = "0.105.1"
 ckb-types = "0.105.1"
 hex = "0.4"
 
-eth_light_client_in_ckb-verification = { version = "0.1.0-alpha.0", git = "https://github.com/yangby-cryptape/eth-light-client-in-ckb", rev = "707d7f6" }
+eth_light_client_in_ckb-verification = { version = "0.1.0-alpha.0", git = "https://github.com/synapseweb3/eth-light-client-in-ckb", rev = "e94ec1a" }


### PR DESCRIPTION
Since this PR upgrades lighthouse to the latest version, many dependencies were removed.

- For example, both `ethereum-types v0.12.1` and `ethereum-types v0.14.1` are depended at present,

  and this PR will remove `ethereum-types v0.12.1`.

Then, the binary size will be smaller and compile time will be less.
