### PR TITLE
feat: implement axon proof generation

### DIFF
--- a/crates/relayer/src/chain/axon.rs
+++ b/crates/relayer/src/chain/axon.rs
@@ -718,8 +718,8 @@ impl ChainEndpoint for AxonChain {
         let tx_hash = self.conn_tx_hash.get(&key).unwrap();
         let (tx, tx_receipt, block) = self.get_proof_ingredients(connection_id.clone(), *tx_hash)?;
 
-        let object_proof = todo!("build proof with transaction and block");
-        let client_proof = todo!("build client proof");
+        todo!("object_proof: build proof with transaction and block");
+        todo!("client_proof: build client proof");
         todo!("assemble Proofs");
     }
 

--- a/crates/relayer/src/chain/axon.rs
+++ b/crates/relayer/src/chain/axon.rs
@@ -768,14 +768,14 @@ impl ChainEndpoint for AxonChain {
         todo!("assemble Proofs");
     }
 
-    fn save_conn_tx_hash(
+    fn save_conn_tx_hash<T: Into<[u8; 32]>>(
         &mut self,
         connection_id: &ConnectionId,
         state: connection::State,
-        tx_hash: [u8; 32],
+        tx_hash: T,
     ) -> Result<(), Error> {
         self.conn_tx_hash
-            .insert((connection_id.clone(), state), tx_hash);
+            .insert((connection_id.clone(), state), tx_hash.into());
         Ok(())
     }
 }

--- a/crates/relayer/src/chain/endpoint.rs
+++ b/crates/relayer/src/chain/endpoint.rs
@@ -685,4 +685,13 @@ pub trait ChainEndpoint: Sized {
         &self,
         request: QueryIncentivizedPacketRequest,
     ) -> Result<QueryIncentivizedPacketResponse, Error>;
+
+    fn save_conn_tx_hash(
+        &mut self,
+        _connection_id: &ConnectionId,
+        _state: State,
+        _tx_hash: [u8; 32],
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }

--- a/crates/relayer/src/chain/endpoint.rs
+++ b/crates/relayer/src/chain/endpoint.rs
@@ -686,11 +686,11 @@ pub trait ChainEndpoint: Sized {
         request: QueryIncentivizedPacketRequest,
     ) -> Result<QueryIncentivizedPacketResponse, Error>;
 
-    fn save_conn_tx_hash(
+    fn save_conn_tx_hash<T: Into<[u8; 32]>>(
         &mut self,
         _connection_id: &ConnectionId,
         _state: State,
-        _tx_hash: [u8; 32],
+        _tx_hash: T,
     ) -> Result<(), Error> {
         Ok(())
     }

--- a/crates/relayer/src/chain/handle.rs
+++ b/crates/relayer/src/chain/handle.rs
@@ -12,7 +12,7 @@ use ibc_relayer_types::{
     core::{
         ics02_client::events::UpdateClient,
         ics03_connection::{
-            connection::{ConnectionEnd, IdentifiedConnectionEnd, self},
+            connection::{self, ConnectionEnd, IdentifiedConnectionEnd},
             version::Version,
         },
         ics04_channel::{
@@ -686,11 +686,11 @@ pub trait ChainHandle: Clone + Display + Send + Sync + Debug + 'static {
         request: QueryIncentivizedPacketRequest,
     ) -> Result<QueryIncentivizedPacketResponse, Error>;
 
-    fn save_conn_tx_hash(
+    fn save_conn_tx_hash<T: Into<[u8; 32]>>(
         &mut self,
         _connection_id: &ConnectionId,
         _state: connection::State,
-        _tx_hash: [u8; 32],
+        _tx_hash: T,
     ) -> Result<(), Error> {
         Ok(())
     }

--- a/crates/relayer/src/chain/handle.rs
+++ b/crates/relayer/src/chain/handle.rs
@@ -12,7 +12,7 @@ use ibc_relayer_types::{
     core::{
         ics02_client::events::UpdateClient,
         ics03_connection::{
-            connection::{ConnectionEnd, IdentifiedConnectionEnd},
+            connection::{ConnectionEnd, IdentifiedConnectionEnd, self},
             version::Version,
         },
         ics04_channel::{
@@ -367,6 +367,13 @@ pub enum ChainRequest {
         request: QueryIncentivizedPacketRequest,
         reply_to: ReplyTo<QueryIncentivizedPacketResponse>,
     },
+
+    SaveConnTxHash {
+        connection_id: ConnectionId,
+        state: connection::State,
+        tx_hash: [u8; 32],
+        reply_to: ReplyTo<()>,
+    },
 }
 
 pub trait ChainHandle: Clone + Display + Send + Sync + Debug + 'static {
@@ -678,4 +685,13 @@ pub trait ChainHandle: Clone + Display + Send + Sync + Debug + 'static {
         &self,
         request: QueryIncentivizedPacketRequest,
     ) -> Result<QueryIncentivizedPacketResponse, Error>;
+
+    fn save_conn_tx_hash(
+        &mut self,
+        _connection_id: &ConnectionId,
+        _state: connection::State,
+        _tx_hash: [u8; 32],
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }

--- a/crates/relayer/src/chain/handle/base.rs
+++ b/crates/relayer/src/chain/handle/base.rs
@@ -11,7 +11,7 @@ use ibc_relayer_types::{
     core::{
         ics02_client::events::UpdateClient,
         ics03_connection::connection::{ConnectionEnd, IdentifiedConnectionEnd},
-        ics03_connection::version::Version,
+        ics03_connection::{version::Version, connection},
         ics04_channel::channel::{ChannelEnd, IdentifiedChannelEnd},
         ics04_channel::packet::{PacketMsgType, Sequence},
         ics23_commitment::{commitment::CommitmentPrefix, merkle::MerkleProof},
@@ -514,5 +514,19 @@ impl ChainHandle for BaseChainHandle {
         request: QueryIncentivizedPacketRequest,
     ) -> Result<QueryIncentivizedPacketResponse, Error> {
         self.send(|reply_to| ChainRequest::QueryIncentivizedPacket { request, reply_to })
+    }
+
+    fn save_conn_tx_hash(
+        &mut self,
+        connection_id: &ConnectionId,
+        state: connection::State,
+        tx_hash: [u8; 32],
+    ) -> Result<(), Error> {
+        self.send(|reply_to| ChainRequest::SaveConnTxHash {
+            connection_id: connection_id.clone(),
+            state,
+            tx_hash,
+            reply_to,
+        })
     }
 }

--- a/crates/relayer/src/chain/handle/base.rs
+++ b/crates/relayer/src/chain/handle/base.rs
@@ -11,7 +11,7 @@ use ibc_relayer_types::{
     core::{
         ics02_client::events::UpdateClient,
         ics03_connection::connection::{ConnectionEnd, IdentifiedConnectionEnd},
-        ics03_connection::{version::Version, connection},
+        ics03_connection::{connection, version::Version},
         ics04_channel::channel::{ChannelEnd, IdentifiedChannelEnd},
         ics04_channel::packet::{PacketMsgType, Sequence},
         ics23_commitment::{commitment::CommitmentPrefix, merkle::MerkleProof},
@@ -516,16 +516,16 @@ impl ChainHandle for BaseChainHandle {
         self.send(|reply_to| ChainRequest::QueryIncentivizedPacket { request, reply_to })
     }
 
-    fn save_conn_tx_hash(
+    fn save_conn_tx_hash<T: Into<[u8; 32]>>(
         &mut self,
         connection_id: &ConnectionId,
         state: connection::State,
-        tx_hash: [u8; 32],
+        tx_hash: T,
     ) -> Result<(), Error> {
         self.send(|reply_to| ChainRequest::SaveConnTxHash {
             connection_id: connection_id.clone(),
             state,
-            tx_hash,
+            tx_hash: tx_hash.into(),
             reply_to,
         })
     }

--- a/crates/relayer/src/chain/runtime.rs
+++ b/crates/relayer/src/chain/runtime.rs
@@ -13,7 +13,7 @@ use ibc_relayer_types::{
     core::{
         ics02_client::events::UpdateClient,
         ics03_connection::{
-            connection::{ConnectionEnd, IdentifiedConnectionEnd, self},
+            connection::{self, ConnectionEnd, IdentifiedConnectionEnd},
             version::Version,
         },
         ics04_channel::{
@@ -856,11 +856,11 @@ where
         Ok(())
     }
 
-    fn save_conn_tx_hash(
+    fn save_conn_tx_hash<T: Into<[u8; 32]>>(
         &mut self,
         conn_id: ConnectionId,
         state: connection::State,
-        tx_hash: [u8; 32],
+        tx_hash: T,
         reply_to: ReplyTo<()>,
     ) -> Result<(), Error> {
         let result = self.chain.save_conn_tx_hash(&conn_id, state, tx_hash);

--- a/crates/relayer/src/chain/runtime.rs
+++ b/crates/relayer/src/chain/runtime.rs
@@ -13,7 +13,7 @@ use ibc_relayer_types::{
     core::{
         ics02_client::events::UpdateClient,
         ics03_connection::{
-            connection::{ConnectionEnd, IdentifiedConnectionEnd},
+            connection::{ConnectionEnd, IdentifiedConnectionEnd, self},
             version::Version,
         },
         ics04_channel::{
@@ -349,6 +349,11 @@ where
                         ChainRequest::QueryIncentivizedPacket { request, reply_to } => {
                             self.query_incentivized_packet(request, reply_to)?
                         },
+
+                        ChainRequest::SaveConnTxHash { connection_id, state,  tx_hash, reply_to } => {
+                            self.save_conn_tx_hash(connection_id, state, tx_hash, reply_to)?
+                        },
+
                     }
                 },
             }
@@ -848,6 +853,18 @@ where
         let result = self.chain.query_incentivized_packet(request);
         reply_to.send(result).map_err(Error::send)?;
 
+        Ok(())
+    }
+
+    fn save_conn_tx_hash(
+        &mut self,
+        conn_id: ConnectionId,
+        state: connection::State,
+        tx_hash: [u8; 32],
+        reply_to: ReplyTo<()>,
+    ) -> Result<(), Error> {
+        let result = self.chain.save_conn_tx_hash(&conn_id, state, tx_hash);
+        reply_to.send(result).map_err(Error::send)?;
         Ok(())
     }
 }

--- a/crates/relayer/src/connection.rs
+++ b/crates/relayer/src/connection.rs
@@ -1341,7 +1341,7 @@ pub fn extract_connection_id(event: &IbcEvent) -> Result<&ConnectionId, Connecti
 }
 
 /// Enumeration of proof carrying ICS3 message, helper for relayer.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ConnectionMsgType {
     OpenTry,
     OpenAck,

--- a/crates/relayer/src/connection.rs
+++ b/crates/relayer/src/connection.rs
@@ -1341,7 +1341,7 @@ pub fn extract_connection_id(event: &IbcEvent) -> Result<&ConnectionId, Connecti
 }
 
 /// Enumeration of proof carrying ICS3 message, helper for relayer.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ConnectionMsgType {
     OpenTry,
     OpenAck,

--- a/crates/relayer/src/event.rs
+++ b/crates/relayer/src/event.rs
@@ -34,17 +34,31 @@ pub mod rpc;
 pub struct IbcEventWithHeight {
     pub event: IbcEvent,
     pub height: Height,
+    pub tx_hash: [u8; 32],
 }
 
 impl IbcEventWithHeight {
     pub fn new(event: IbcEvent, height: Height) -> Self {
-        Self { event, height }
+        Self {
+            event,
+            height,
+            tx_hash: Default::default(),
+        }
+    }
+
+    pub fn new_with_tx_hash(event: IbcEvent, height: Height, tx_hash: [u8; 32]) -> Self {
+        Self {
+            event,
+            height,
+            tx_hash,
+        }
     }
 
     pub fn with_height(self, height: Height) -> Self {
         Self {
             event: self.event,
             height,
+            tx_hash: self.tx_hash,
         }
     }
 }

--- a/crates/relayer/src/worker/connection.rs
+++ b/crates/relayer/src/worker/connection.rs
@@ -40,10 +40,7 @@ pub fn spawn_connection_worker<ChainA: ChainHandle, ChainB: ChainHandle>(
 
                         complete_handshake_on_new_block = false;
                         if let Some(event_with_height) = last_event_with_height {
-                            // chains.a.
-                            // chains.a.save_conn_tx_hash(connection_id, message_type, tx_hash)
                             let tx_hash = event_with_height.tx_hash;
-
                             match event_with_height.event.clone() {
                                 OpenTryConnection(open_try) => {
                                     let attr = open_try.0;


### PR DESCRIPTION
Implementation overview
- Save `tx_hash` to `IbcEventWithHeight` at monitoring.
- Add default method `save_conn_tx_hash` in ChainEndPoint
- Axon ChainEndPoint maintains a hashMap for `(ConnectionId, State) -> tx_hash`
- `build_connection_proofs_and_client_state` get transaction and block by `tx_hash` in self's hashMap