### PR TITLE
feat: take place with official get_metadata_by_number rpc

### DIFF
--- a/.github/workflows/cargo-doc.yaml
+++ b/.github/workflows/cargo-doc.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-02-09
+          toolchain: stable-2023-02-09
           override: true
 
       - name: Build API documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,17 +107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-dependencies = [
- "cfg-if 1.0.0",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,20 +284,19 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axon-tools"
-version = "0.0.5"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c33f15ba04ade866232f92a5bb0c06ca7a6103c880802e4823242294ad1999"
+checksum = "f4d858895e2d8232900b764c1f3068780f94fada5b27c3b6ceb89557b528ae7c"
 dependencies = [
  "bit-vec",
  "blst",
  "bytes",
  "ethereum-types",
- "keccak-hasher",
- "memory-db",
+ "ethers",
  "rlp",
  "rlp-derive",
  "serde",
- "trie-db",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -1758,7 +1746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown 0.12.3",
+ "hashbrown",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -2278,11 +2266,11 @@ dependencies = [
 
 [[package]]
 name = "eth_light_client_in_ckb-prover"
-version = "0.2.0-alpha"
-source = "git+https://github.com/synapseweb3/eth-light-client-in-ckb?rev=5a5dc2e#5a5dc2ee18736d492d0a73de691a375f0daf9ff3"
+version = "0.1.0"
+source = "git+https://github.com/synapseweb3/eth-light-client-in-ckb?branch=release/v0.1.x#0113793945a4ddace94e420420881ee38d95b4bb"
 dependencies = [
  "cita_trie",
- "eth_light_client_in_ckb-verification 0.2.0-alpha",
+ "eth_light_client_in_ckb-verification",
  "ethers-core",
  "hasher",
  "merkle_proof",
@@ -2293,27 +2281,7 @@ dependencies = [
 [[package]]
 name = "eth_light_client_in_ckb-verification"
 version = "0.1.0"
-source = "git+https://github.com/synapseweb3/eth-light-client-in-ckb?rev=054d9ae#054d9aeb8c7c405deb10db53ccf28bb78296a31f"
-dependencies = [
- "ckb-merkle-mountain-range",
- "eth2_hashing",
- "eth2_ssz",
- "eth2_ssz_derive",
- "eth2_ssz_types",
- "log",
- "merkle_proof",
- "molecule",
- "rlp",
- "tiny-keccak",
- "tree_hash",
- "tree_hash_derive",
- "types",
-]
-
-[[package]]
-name = "eth_light_client_in_ckb-verification"
-version = "0.2.0-alpha"
-source = "git+https://github.com/synapseweb3/eth-light-client-in-ckb?rev=5a5dc2e#5a5dc2ee18736d492d0a73de691a375f0daf9ff3"
+source = "git+https://github.com/synapseweb3/eth-light-client-in-ckb?branch=release/v0.1.x#0113793945a4ddace94e420420881ee38d95b4bb"
 dependencies = [
  "ckb-merkle-mountain-range",
  "eth2_hashing",
@@ -2764,7 +2732,7 @@ dependencies = [
  "ckb-jsonrpc-types",
  "ckb-sdk",
  "ckb-types",
- "eth_light_client_in_ckb-verification 0.1.0",
+ "eth_light_client_in_ckb-verification",
  "hex",
  "ibc-relayer",
 ]
@@ -3133,36 +3101,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash-db"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7d7786361d7425ae2fe4f9e407eb0efaa0840f5212d109cc018c40c35c6ab4"
-
-[[package]]
-name = "hash256-std-hasher"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c171d55b98633f4ed3860808f004099b36c1cc29c42cfc53aa8591b21efcf2"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.6",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.3",
+ "ahash",
 ]
 
 [[package]]
@@ -3189,7 +3133,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -3557,7 +3501,7 @@ dependencies = [
  "ed25519-dalek-bip32",
  "env_logger 0.10.0",
  "eth_light_client_in_ckb-prover",
- "eth_light_client_in_ckb-verification 0.2.0-alpha",
+ "eth_light_client_in_ckb-verification",
  "ethers",
  "eyre",
  "flex-error",
@@ -3676,7 +3620,7 @@ name = "ibc-relayer-storage"
 version = "0.1.0"
 dependencies = [
  "ckb-rocksdb",
- "eth_light_client_in_ckb-verification 0.2.0-alpha",
+ "eth_light_client_in_ckb-verification",
  "thiserror",
  "types",
 ]
@@ -3875,7 +3819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -4048,17 +3992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak-hasher"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ea4653859ca2266a86419d3f592d3f22e7a854b482f99180d2498507902048"
-dependencies = [
- "hash-db",
- "hash256-std-hasher",
- "tiny-keccak",
-]
-
-[[package]]
 name = "kqueue"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4198,7 +4131,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -4330,15 +4263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "memory-db"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808b50db46293432a45e63bc15ea51e0ab4c0a1647b8eb114e31a3e698dd6fbe"
-dependencies = [
- "hash-db",
 ]
 
 [[package]]
@@ -4872,7 +4796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -7571,18 +7495,6 @@ dependencies = [
  "darling",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "trie-db"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767abe6ffed88a1889671a102c2861ae742726f52e0a5a425b92c9fbfa7e9c85"
-dependencies = [
- "hash-db",
- "hashbrown 0.13.2",
- "log",
- "smallvec",
 ]
 
 [[package]]

--- a/crates/relayer-storage/Cargo.toml
+++ b/crates/relayer-storage/Cargo.toml
@@ -15,4 +15,4 @@ description  = "The storage part of SynapseWeb3 IBC Relayer"
 thiserror = "1.0.37"
 rocksdb = { package = "ckb-rocksdb", version ="=0.19.0", default-features = false, features = ["snappy"] }
 eth2_types = { git = "https://github.com/synapseweb3/lighthouse", rev = "2c246d6", package = "types" }
-eth_light_client_in_ckb-verification = { version = "0.2.0-alpha", git = "https://github.com/synapseweb3/eth-light-client-in-ckb", rev = "5a5dc2e" }
+eth_light_client_in_ckb-verification = { git = "https://github.com/synapseweb3/eth-light-client-in-ckb", branch = "release/v0.1.x" }

--- a/crates/relayer-types/Cargo.toml
+++ b/crates/relayer-types/Cargo.toml
@@ -52,7 +52,7 @@ tree_hash_derive = { git = "https://github.com/synapseweb3/lighthouse", rev = "2
 thiserror = "1.0"
 ethereum-types = "0.14.1"
 hex = "0.4"
-axon-tools = { version = "0.0.5", features = ["impl-serde"] }
+axon-tools = { version = "0.0.8", features = ["impl-serde"] }
 
 [dependencies.tendermint]
 version = "0.30.0"

--- a/crates/relayer/Cargo.toml
+++ b/crates/relayer/Cargo.toml
@@ -30,9 +30,9 @@ eth2_types       = { git = "https://github.com/synapseweb3/lighthouse", rev = "2
 tree_hash_derive = { git = "https://github.com/synapseweb3/lighthouse", rev = "2c246d6" }
 tree_hash        = { git = "https://github.com/synapseweb3/lighthouse", rev = "2c246d6" }
 
-eth_light_client_in_ckb-verification = { version = "0.2.0-alpha", git = "https://github.com/synapseweb3/eth-light-client-in-ckb", rev = "5a5dc2e" }
-eth_light_client_in_ckb-prover = { version = "0.2.0-alpha", git = "https://github.com/synapseweb3/eth-light-client-in-ckb", rev = "5a5dc2e" }
-axon-tools = { version = "0.0.5", features = ["proof", "impl-serde", "trie"] }
+eth_light_client_in_ckb-verification = { git = "https://github.com/synapseweb3/eth-light-client-in-ckb", branch = "release/v0.1.x" }
+eth_light_client_in_ckb-prover = { git = "https://github.com/synapseweb3/eth-light-client-in-ckb", branch = "release/v0.1.x" }
+axon-tools = { version = "0.0.8", features = ["proof", "impl-serde", "abi"] }
 
 subtle-encoding = "0.5"
 humantime-serde = "1.1.1"

--- a/crates/relayer/src/chain/axon/rpc.rs
+++ b/crates/relayer/src/chain/axon/rpc.rs
@@ -1,8 +1,8 @@
 use crate::error::Error;
 
 use async_trait::async_trait;
-use axon_tools::types::{AxonBlock, Proof, Validator};
-use ethers::types::BlockId;
+use axon_tools::types::{AxonBlock, CkbRelatedInfo, Metadata, Proof};
+use ethers::types::{BlockId, BlockNumber};
 use reqwest::Client;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -16,7 +16,11 @@ pub trait AxonRpc {
 
     async fn get_proof_by_id(&self, block_id: BlockId) -> Response<Proof>;
 
-    async fn get_validators(&self) -> Response<Vec<Validator>>;
+    async fn get_metadata_by_number(&self, block_number: BlockNumber) -> Response<Metadata>;
+
+    async fn get_current_metadata(&self) -> Response<Metadata>;
+
+    async fn get_ckb_related_info(&self) -> Response<CkbRelatedInfo>;
 }
 
 #[derive(Clone)]
@@ -81,7 +85,15 @@ impl AxonRpc for AxonRpcClient {
         jsonrpc!("axon_getProofById", self, Proof, block_id)
     }
 
-    async fn get_validators(&self) -> Response<Vec<Validator>> {
-        jsonrpc!("axon_getValidatorsById", self, Vec<Validator>)
+    async fn get_metadata_by_number(&self, block_number: BlockNumber) -> Response<Metadata> {
+        jsonrpc!("axon_getMetadataByNumber", self, Metadata, block_number)
+    }
+
+    async fn get_current_metadata(&self) -> Response<Metadata> {
+        jsonrpc!("axon_getCurrentMetadata", self, Metadata)
+    }
+
+    async fn get_ckb_related_info(&self) -> Response<CkbRelatedInfo> {
+        jsonrpc!("axon_getCkbRelatedInfo", self, CkbRelatedInfo)
     }
 }

--- a/crates/relayer/src/chain/ckb.rs
+++ b/crates/relayer/src/chain/ckb.rs
@@ -255,7 +255,7 @@ impl CkbChain {
             hash,
             Duration::from_secs(3),
             0,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         ))?;
 
         Ok(())

--- a/crates/relayer/src/chain/ckb/helper.rs
+++ b/crates/relayer/src/chain/ckb/helper.rs
@@ -64,7 +64,7 @@ pub trait CellSearcher: CkbReader {
                 let errmsg = format!(
                     "no enough ckb ({searched_capacity}/{need_capacity}) on address: {address}"
                 );
-                return Err(Error::send_tx(errmsg.to_string()));
+                return Err(Error::send_tx(errmsg));
             }
 
             let mut live_cells = result

--- a/tools/forcerelay-test/Cargo.toml
+++ b/tools/forcerelay-test/Cargo.toml
@@ -9,5 +9,5 @@ ckb-jsonrpc-types = "0.106.0"
 ckb-types = "0.106.0"
 hex = "0.4"
 
-eth_light_client_in_ckb-verification = { version = "0.1.0", git = "https://github.com/synapseweb3/eth-light-client-in-ckb", rev = "054d9ae" }
+eth_light_client_in_ckb-verification = { git = "https://github.com/synapseweb3/eth-light-client-in-ckb", branch = "release/v0.1.x" }
 relayer = {version = "*", package = "ibc-relayer", path = "../../crates/relayer"}


### PR DESCRIPTION
chore: downgrade eth prover and verification

chore: adjust cargo-doc.yaml

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description
Axon updated the final `axon-tools` crate to v0.0.8 which enables getting metadata with or without block number and leaving `CkbRelatedInfo` to support getting ckb info about on-chain cells

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Forcerelay) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
