### PR TITLE
fix: bls verification security issue for eth light client

### DIFF
--- a/crates/relayer/src/light_client/eth/utils.rs
+++ b/crates/relayer/src/light_client/eth/utils.rs
@@ -134,7 +134,7 @@ pub fn compute_fork_data_root(
 pub fn is_aggregate_valid(sig: &SignatureBytes, msg: H256, pks: &[&PublicKey]) -> bool {
     let valid = AggregateSignature::deserialize(sig.as_ref())
         .ok()
-        .map(|signature| signature.eth_fast_aggregate_verify(msg, pks));
+        .map(|signature| signature.fast_aggregate_verify(msg, pks));
     valid.unwrap_or(false)
 }
 


### PR DESCRIPTION
## Description


- As I known, this piece of code was copied from [`helios`], and it called [`milagro_bls::fast_aggregate_verify(..)`] to do verification.

  - [`milagro_bls::fast_aggregate_verify(..)`] returns **false** if there are no public keys.

- But in our project, if called [`lighthouse::eth_fast_aggregate_verify(..)`] to do verification.

  - [`lighthouse::eth_fast_aggregate_verify(..)`] returns **true** if there are no public keys but `G2` is infinity.

- I checked the Ethereum Proof-of-Stake Consensus Specifications:
  - [`eth_fast_aggregate_verify`] was defined in the spec, and [`lighthouse::eth_fast_aggregate_verify(..)`] was implemented correctly.
  - But when do [`validate_light_client_update`], it called `bls.FastAggregateVerify(..)` directly (see the last line in the function), which returns **false** when there are no public keys without any exceptions.

[`helios`]: https://github.com/a16z/helios/blob/ff800484bc0cb4d5ea55979da235f555eee1c90c/consensus/src/utils.rs#L16
[`milagro_bls::fast_aggregate_verify(..)`]: https://github.com/sigp/milagro_bls/blob/421aa3af8a0618a46144560389debbe7e56609db/src/aggregates.rs#L179-L181
[`lighthouse::eth_fast_aggregate_verify(..)`]: https://github.com/synapseweb3/lighthouse/blob/693886b94176faa4cb450f024696cb69cda2fe58/crypto/bls/src/generic_aggregate_signature.rs#L205
[`eth_fast_aggregate_verify`]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/altair/bls.md#eth_fast_aggregate_verify
[`validate_light_client_update`]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/altair/light-client/sync-protocol.md#validate_light_client_update