### PR TITLE
Remove `curl` and `sed` from ckb4ibc tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,7 @@ dependencies = [
  "tiny-keccak",
  "tokio",
  "toml 0.5.11",
+ "toml_edit",
 ]
 
 [[package]]

--- a/tools/ckb4ibc-test/Cargo.toml
+++ b/tools/ckb4ibc-test/Cargo.toml
@@ -30,3 +30,4 @@ ibc-test-framework = { path = "../test-framework" }
 toml = "=0.5.11"
 anyhow = "1.0.72"
 log = "0.4.19"
+toml_edit = "0.19.14"


### PR DESCRIPTION
## Description

This PR is follows #282 

1. remove `curl` dependent
2. remove `sed` dependent