### PR TITLE
chore: uncomment axon_tools::verify_trie_proof

### DIFF
--- a/.github/workflows/ibc-test.yaml
+++ b/.github/workflows/ibc-test.yaml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 60
     env:
       SRC_DIR: ${{ github.workspace }}/ibc-test-src
-      AXON_COMMIT: d03d2bb7cb3dcdc03319c3a74beeee6715e7f448
+      AXON_COMMIT: 7ae0a826647d07e0b25b4adb440a8c97231d6a04
       IBC_CONTRACT_COMMIT: 5746d048304ca4d73dc4800459ddd79d57fa124c
     strategy:
       fail-fast: false

--- a/crates/relayer/src/chain/axon.rs
+++ b/crates/relayer/src/chain/axon.rs
@@ -1017,12 +1017,10 @@ impl AxonChain {
             .rt
             .block_on(self.get_proofs_ingredients(block_number))?;
 
-        // FIXME: keep it commentted until Axon team fixed this verify issue
-        //
         // check the validation of receipts mpt proof
-        // let key = rlp::encode(&receipt.transaction_index.as_u64());
-        // axon_tools::verify_trie_proof(block.header.receipts_root, &key, receipt_proof.clone())
-        //     .map_err(|e| Error::rpc_response(format!("unverified receipts mpt: {e:?}")))?;
+        let key = rlp::encode(&receipt.transaction_index.as_u64());
+        axon_tools::verify_trie_proof(block.header.receipts_root, &key, receipt_proof.clone())
+            .map_err(|e| Error::rpc_response(format!("unverified receipts mpt: {e:?}")))?;
 
         let object_proof =
             to_ckb_like_object_proof(&receipt, &receipt_proof, &block, &state_root, &block_proof)


### PR DESCRIPTION
- Closes: #264 

## Description

since Axon has solved the compatibility issue about `receipts_mpt_root` with the authentic implementation of Ethereum, we can uncomment the comments and test whether this works as we expected while calling [axon_tools::verify_trie_root](https://github.com/synapseweb3/forcerelay/blob/chore/uncomment-verify-trie-proof/crates/relayer/src/chain/axon.rs#L1021-L1023) method.

Note: CI process uses https://github.com/axonweb3/axon/commits/d03d2bb7cb3dcdc03319c3a74beeee6715e7f448 commit of Axon