### PR TITLE
fix: check monitor threads are still working after ibc tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3707,6 +3707,7 @@ dependencies = [
  "tiny-bip39",
  "tiny-keccak",
  "tokio",
+ "tokio-stream",
  "toml 0.5.11",
  "tonic",
  "tracing",

--- a/crates/relayer/Cargo.toml
+++ b/crates/relayer/Cargo.toml
@@ -49,6 +49,7 @@ tokio = { version = "1.0", features = [
     "sync",
     "parking_lot",
 ] }
+tokio-stream = "0.1"
 serde_json = { version = "1" }
 bytes = "1.4.0"
 prost = { version = "0.11" }

--- a/tools/ibc-test/src/framework/binary/channel.rs
+++ b/tools/ibc-test/src/framework/binary/channel.rs
@@ -108,6 +108,10 @@ where
         chains: ConnectedChains<ChainA, ChainB>,
         channel: ConnectedChannel<ChainA, ChainB>,
     ) -> Result<(), Error> {
-        self.test.run(config, relayer, chains, channel)
+        self.test.run(config, relayer, chains.clone(), channel)?;
+        log::info!("check monitor threads are still working");
+        let _ = chains.handle_a().subscribe().map_err(Error::relayer)?;
+        let _ = chains.handle_b().subscribe().map_err(Error::relayer)?;
+        Ok(())
     }
 }


### PR DESCRIPTION
Fix monitor silently crashed issue https://github.com/synapseweb3/forcerelay/pull/330#issuecomment-1727847526

We noticed sometimes CI returns success but the monitor thread is crashed silently, which is unexpected.

This PR adds code to check monitor is working at the end of ibc tests, and returns an error if it isn't working.

We call subscribe function of ChainEndpoint to check the monitor thread, if the monitor is crashed, the subscribe will return a `SendError` error, we converted it to `Error::Relayer`.