### PR TITLE
Fix ibc-test workflow

### DIFF
--- a/.github/workflows/ibc-test.yaml
+++ b/.github/workflows/ibc-test.yaml
@@ -82,7 +82,6 @@ jobs:
         env:
           cache-name: cache-axon-bin
         with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ${{env.SRC_DIR}}/axon/target/release/axon
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.AXON_COMMIT }}
   

--- a/.github/workflows/ibc-test.yaml
+++ b/.github/workflows/ibc-test.yaml
@@ -9,7 +9,8 @@ on:
       - crates/**
       - tools/**
   push:
-    branches: main
+    branches: [main, '*test*']
+    paths:
       - .github/workflows/ibc-test.yaml
       - Cargo.toml
       - Cargo.lock


### PR DESCRIPTION
### [Fix the push event in ibc-test workflow](https://github.com/synapseweb3/forcerelay/commit/0319a0cd27681a072237aa7bda486447d9c2a46b) because the `paths` filter is missing.


### Reviewer checklist:

- [x] Reviewed `Files changed` in the GitHub PR explorer.
