### PR TITLE
Revert "fix: ckb4ibc monitor crash in CI"

### DIFF
--- a/tools/test-framework/src/types/single/node.rs
+++ b/tools/test-framework/src/types/single/node.rs
@@ -155,8 +155,7 @@ impl FullNode {
         // normally we cannot put same `client_cell_type_args` in config.toml, because
         // Forcerelay/Axon assumes each counterparty chain has its own unique `client_id`
         // to figure out unique `client_type` and `chain_id`
-        let chains_str = std::env::var("ACCOUNT_PREFIXES").unwrap();
-        if chains_str.contains("axon") {
+        if std::env::var("ACCOUNT_PREFIXES").unwrap().contains("axon") {
             let counterparty_chain_id = if this_chain_id.to_string() == "ckb4ibc-0" {
                 ChainId::from_string("axon-1")
             } else {
@@ -169,8 +168,7 @@ impl FullNode {
                     client_cell_type_args: h256_env("CLIENT_TYPE_ARGS").into(),
                 },
             );
-        }
-        if chains_str.contains("ckb") {
+        } else {
             let counterparty_chain_id = if this_chain_id.to_string() == "ckb4ibc-0" {
                 ChainId::from_string("ckb4ibc-1")
             } else {


### PR DESCRIPTION
Reverts synapseweb3/forcerelay#342

#342  introduces a bug, a duplicated `client_cell_type_args` is inserted the configure, it causes the CKB chain endpoint returns a wrong light client chain id.