### PR TITLE
feat(ibc-test): use ICS20TransferERC20, remove MockTransfer

### DIFF
--- a/.github/workflows/ibc-test.yaml
+++ b/.github/workflows/ibc-test.yaml
@@ -29,7 +29,7 @@ jobs:
     env:
       SRC_DIR: ${{ github.workspace }}/ibc-test-src
       AXON_COMMIT: d03d2bb7cb3dcdc03319c3a74beeee6715e7f448
-      IBC_CONTRACT_COMMIT: f407f44289ef8abea31860b963f758dae1c16071
+      IBC_CONTRACT_COMMIT: 35290d79c9fa45583b00f228dd3ed7e8468ccc67
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Detailed deployment steps can be found in [ibc-ckb-contracts](https://github.com
 |escrow|WIP|WIP|
 
 ### Business Module Registration
-When deploying the Solidity contract on Axon, an initial ICS20 transfer module is automatically registered in `OwnableIBCHandler` on port `port-0` during the contract migration process. This registration is open to all users. For detailed instructions on how to register your own business module, visit [ibc-solidity-contract](https://github.com/synapseweb3/ibc-solidity-contract) repository.
+When deploying the Solidity contract on Axon, an initial ICS20 transfer module is automatically registered in `OwnableIBCHandler` on port `transfer` during the contract migration process. This registration is open to all users. For detailed instructions on how to register your own business module, visit [ibc-solidity-contract](https://github.com/synapseweb3/ibc-solidity-contract) repository.
 
 Unlike Axon, business modules cannot be registered directly with a contract on CKB. To address this, we have introduced [forcerelay-ckb-sdk](https://github.com/synapseweb3/forcerelay-ckb-sdk), designed to facilitate the distribution and calling of custom modules.
 
@@ -89,7 +89,7 @@ Establishing IBC channels on both sides of Axon and CKB is required to run Force
 ```
 $ forcerelay create channel \
     --a-chain axon-0 --b-chain ckb4ibc-0 \
-    --a-port  port-0 --b-port <WALLET_LOCK_HASH> \
+    --a-port  transfer --b-port <WALLET_LOCK_HASH> \
     --new-client-connection
 $ forcerelay start --config <YOUR_CONFIG_PATH>
 ```

--- a/crates/relayer/src/chain/ckb4ibc.rs
+++ b/crates/relayer/src/chain/ckb4ibc.rs
@@ -609,6 +609,9 @@ impl ChainEndpoint for Ckb4IbcChain {
     }
 
     fn ibc_version(&self) -> Result<Option<Version>, Error> {
+        // TODO @jjy
+        // the ibc version should be matched with the CKB contract,
+        // IMO we can put it into the config of forcerelay or save the version in a cell
         Ok(None)
     }
 
@@ -749,6 +752,7 @@ impl ChainEndpoint for Ckb4IbcChain {
         Ok(responses)
     }
 
+    // TODO verify target height with Axon light client / store
     fn verify_header(
         &mut self,
         _trusted: Height,
@@ -819,6 +823,7 @@ impl ChainEndpoint for Ckb4IbcChain {
         Ok(vec![ckb_balance])
     }
 
+    // TODO Need to align with CKB ibc contract
     fn query_denom_trace(&self, _hash: String) -> Result<DenomTrace, Error> {
         warn!("axon query_denom_trace() cannot implement");
         Ok(DenomTrace {
@@ -849,6 +854,7 @@ impl ChainEndpoint for Ckb4IbcChain {
             .onchain_light_clients
             .keys()
             .map(|client_type| {
+                // TODO query latest_height from light client cell (for example Axon metadata cell)
                 let client_id = self.config.lc_client_id(*client_type).unwrap();
                 let chain_id = self.config.lc_chain_id(&client_id.to_string()).unwrap();
                 IdentifiedAnyClientState {
@@ -869,6 +875,7 @@ impl ChainEndpoint for Ckb4IbcChain {
         _include_proof: IncludeProof,
     ) -> Result<(AnyClientState, Option<MerkleProof>), Error> {
         let chain_id = self.config.lc_chain_id(&request.client_id.to_string())?;
+        // TODO query latest_height
         let client_state = CkbClientState {
             chain_id,
             latest_height: Height::default(),

--- a/tools/ibc-test/README.md
+++ b/tools/ibc-test/README.md
@@ -15,7 +15,7 @@ We use chain-A chain-B, connection-A connection-B or channel-A channel-B to repr
 
 `gaia` chain uses a builtin `transfer` port as the default port in IBC tests.
 
-For Axon chain we use `port-0` as default port since it is defined in the [deployment script](https://github.com/synapseweb3/ibc-solidity-contract/blob/master/migrations/1_deploy_contracts.js#L84).
+For Axon chain we use `transfer` as default port.
 
 For CKB chain we uses `blake2b(b"transfer")` as default port.
 

--- a/tools/ibc-test/src/framework/utils/common.rs
+++ b/tools/ibc-test/src/framework/utils/common.rs
@@ -55,7 +55,7 @@ pub fn transfer_port_id(chain_type: ChainType) -> PortId {
         }
         ChainType::Axon => {
             // Axon default port ID
-            PortId::from_str("port-0").unwrap()
+            PortId::from_str("transfer").unwrap()
         }
         _ => {
             unreachable!()

--- a/tools/test-framework/src/types/axon/mod.rs
+++ b/tools/test-framework/src/types/axon/mod.rs
@@ -4,7 +4,6 @@ use serde_derive::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 pub struct DeployedContracts {
     pub contract_address: H160,
-    pub mock_transfer_contract_address: H160,
     pub transfer_contract_address: H160,
     pub image_cell_contract_address: H160,
     pub ckb_light_client_contract_address: H160,


### PR DESCRIPTION
Uses ICS20TransferERC20 to replace the MockTransfer in IBC tests.

We also deployed a SimpleToken(both name and symbol are 'AT') ERC-20 contract used as the default token in IBC tests.

See also https://github.com/synapseweb3/ibc-solidity-contract/pull/29