### PR TITLE
chore: change hermes to forcerelay

### DIFF
--- a/.github/workflows/forcrerelay-test.yaml
+++ b/.github/workflows/forcrerelay-test.yaml
@@ -24,13 +24,13 @@ concurrency:
 jobs:
   forecerelay-test:
     runs-on: ubuntu-20.04
-    timeout-minutes: 75
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - name: add test key
         run: |
-          mkdir -p ~/.hermes/keys/ibc-ckb-0/keyring-test
-          cp ./tools/forcerelay-test/ckb/relayer_ckb_wallet.json ~/.hermes/keys/ibc-ckb-0/keyring-test
+          mkdir -p ~/.forcerelay/keys/ibc-ckb-0/keyring-test
+          cp ./tools/forcerelay-test/ckb/relayer_ckb_wallet.json ~/.forcerelay/keys/ibc-ckb-0/keyring-test
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/forcrerelay-test.yaml
+++ b/.github/workflows/forcrerelay-test.yaml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   forecerelay-test:
     runs-on: ubuntu-20.04
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v3
       - name: add test key

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ cargo install -p ibc-relayer-cli
 $ forcerelay --version
 ```
 
-Forcerelay can be executed by specifying a configuration file in the command line, otherwise it will access the `~/.hermes/config.toml`. We provide a pre-generated [example](https://github.com/synapseweb3/forcerelay/blob/main/config.toml) configuration file written for Axon and CKB (Testnet). To run Forcerelay, only minimal modifications are needed to this configuration:
+Forcerelay can be executed by specifying a configuration file in the command line, otherwise it will access the `~/.forcerelay/config.toml`. We provide a pre-generated [example](https://github.com/synapseweb3/forcerelay/blob/main/config.toml) configuration file written for Axon and CKB (Testnet). To run Forcerelay, only minimal modifications are needed to this configuration:
 
 ```
 websocket_addr = "ws://<YOUR_AXON_URL>:<WS_PORT>"

--- a/crates/relayer-cli/build.rs
+++ b/crates/relayer-cli/build.rs
@@ -8,7 +8,7 @@ fn main() {
     // outputs consistent usage and help messages.
     // https://github.com/informalsystems/hermes/issues/590
     // Note: This can potentially break the normal cargo (or crates.io) workflow.
-    println!("cargo:rustc-env=CARGO_PKG_NAME=forcerelay");
+    println!("cargo:rustc-env=CARGO_PKG_NAME=hermes");
     println!("cargo:rustc-env=CARGO_PKG_VERSION={}", version());
 }
 

--- a/crates/relayer-cli/build.rs
+++ b/crates/relayer-cli/build.rs
@@ -8,7 +8,7 @@ fn main() {
     // outputs consistent usage and help messages.
     // https://github.com/informalsystems/hermes/issues/590
     // Note: This can potentially break the normal cargo (or crates.io) workflow.
-    println!("cargo:rustc-env=CARGO_PKG_NAME=hermes");
+    println!("cargo:rustc-env=CARGO_PKG_NAME=forcerelay");
     println!("cargo:rustc-env=CARGO_PKG_VERSION={}", version());
 }
 

--- a/crates/relayer-cli/src/lib.rs
+++ b/crates/relayer-cli/src/lib.rs
@@ -36,4 +36,4 @@ pub mod error;
 pub mod prelude;
 
 /// The path to the default configuration file, relative to the home directory.
-pub const DEFAULT_CONFIG_PATH: &str = ".hermes/config.toml";
+pub const DEFAULT_CONFIG_PATH: &str = ".forcerelay/config.toml";

--- a/crates/relayer/src/chain/ckb4ibc.rs
+++ b/crates/relayer/src/chain/ckb4ibc.rs
@@ -69,7 +69,7 @@ use std::sync::RwLock;
 use tendermint_rpc::endpoint::broadcast::tx_sync::Response;
 use tokio::runtime::Runtime;
 use tokio::sync::watch::Sender as WatchSender;
-use tracing::log::{info, warn};
+use tracing::log::{error, info, warn};
 
 use self::extractor::{extract_connections_from_tx, extract_ibc_packet_from_tx};
 use self::message::{convert_msg_to_ckb_tx, CkbTxInfo, Converter, MsgToTxConverter};
@@ -372,7 +372,7 @@ impl Ckb4IbcChain {
                     if let Ok(client_type) = self.config.lc_client_type(&client_id) {
                         resps.push((tx, cell_input, capacity, client_type));
                     } else {
-                        warn!("skip local missing client_id found on-chain: {client_id}");
+                        error!("skip local missing client_id found on-chain: {client_id}");
                     }
                 }
                 Ok(resps)

--- a/crates/relayer/src/keyring.rs
+++ b/crates/relayer/src/keyring.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use crate::{chain::ChainType, config::ChainConfig};
 use errors::Error;
 
-pub const KEYSTORE_DEFAULT_FOLDER: &str = ".hermes/keys/";
+pub const KEYSTORE_DEFAULT_FOLDER: &str = ".forcerelay/keys/";
 pub const KEYSTORE_DISK_BACKEND: &str = "keyring-test";
 pub const KEYSTORE_FILE_EXTENSION: &str = "json";
 


### PR DESCRIPTION
## Description
change logs:
1. change config home dir from`.hermes` to `.forcerelay`
2. alter README.md
3. missing client_id should print error not warn
