### PR TITLE
refactor: refactor the monitor and transaction assembly

### DIFF
--- a/crates/relayer/src/chain/axon/monitor.rs
+++ b/crates/relayer/src/chain/axon/monitor.rs
@@ -224,6 +224,7 @@ impl AxonEventMonitor {
             .into_iter()
             .for_each(|(event, meta)| self.process_event(event, meta));
 
+        self.start_block_number = tip_block_number + 1;
         Next::Continue
     }
 

--- a/crates/relayer/src/chain/axon/monitor.rs
+++ b/crates/relayer/src/chain/axon/monitor.rs
@@ -79,7 +79,7 @@ impl AxonEventMonitor {
         Ok((monitor, TxMonitorCmd::new(tx_cmd)))
     }
 
-    // XXX: we met a connection error that ethers-rs doesn't reconnection if it meets error,
+    // XXX: we met a connection error that ethers-rs doesn't reconnect WebSocket if it meets error,
     //      we just choose to recreate provider mannully to solve connection problem
     //
     //      see: https://github.com/gakonst/ethers-rs/issues/2323

--- a/crates/relayer/src/chain/ckb4ibc.rs
+++ b/crates/relayer/src/chain/ckb4ibc.rs
@@ -22,7 +22,7 @@ use crate::keyring::{KeyRing, Secp256k1KeyPair};
 use crate::misbehaviour::MisbehaviourEvidence;
 
 use ckb_ics_axon::handler::{IbcChannel, IbcConnections, IbcPacket, PacketStatus};
-use ckb_ics_axon::message::Envelope;
+use ckb_ics_axon::message::{Envelope, MsgType};
 use ckb_ics_axon::object::Ordering;
 use ckb_ics_axon::{ChannelArgs, PacketArgs};
 use ckb_jsonrpc_types::{Status, TransactionView};
@@ -36,6 +36,7 @@ use ckb_types::molecule::prelude::Entity;
 use ckb_types::packed::{CellInput, OutPoint, Script, WitnessArgs};
 use ckb_types::prelude::{Builder, Pack, Unpack};
 use futures::TryFutureExt;
+use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::apps::fee::v1::{
     QueryIncentivizedPacketRequest, QueryIncentivizedPacketResponse,
 };
@@ -477,6 +478,61 @@ impl Ckb4IbcChain {
             .collect::<Vec<_>>();
         Ok(packets.first().cloned())
     }
+
+    #[allow(clippy::type_complexity)]
+    fn assemble_transaction_from_msg(
+        &self,
+        msg: &Any,
+    ) -> Result<(Option<IbcEvent>, Option<(TransactionView, MsgType)>), Error> {
+        let converter = self.get_converter()?;
+        let CkbTxInfo {
+            unsigned_tx,
+            envelope,
+            input_capacity,
+            event,
+        } = convert_msg_to_ckb_tx(msg, &converter)?;
+        if unsigned_tx.is_none() {
+            return Ok((event, None));
+        }
+        let unsigned_tx = unsigned_tx.unwrap();
+        let msg_type = envelope.msg_type;
+        match self.complete_tx_with_secp256k1_change_and_envelope(
+            unsigned_tx,
+            input_capacity,
+            envelope,
+        ) {
+            Ok(tx) => {
+                let last_input_idx = tx.inputs().len() - 1;
+                let secret_key = self
+                    .keybase
+                    .get_key(&self.config.key_name)
+                    .map_err(Error::key_base)?
+                    .into_ckb_keypair(self.network()?)
+                    .private_key;
+                let signer = SecpSighashScriptSigner::new(Box::new(
+                    SecpCkbRawKeySigner::new_with_secret_keys(vec![secret_key]),
+                ));
+                let tx = signer
+                    .sign_tx(
+                        &tx,
+                        &ScriptGroup {
+                            script: Script::from(&self.tx_assembler_address()?),
+                            group_type: ScriptGroupType::Lock,
+                            // TODO: here should be more indices in case of more than one Secp256k1 cells
+                            //       have been filled in the transaction
+                            input_indices: vec![last_input_idx],
+                            output_indices: vec![],
+                        },
+                    )
+                    .map_err(|err| Error::other_error(err.to_string()))?;
+                Ok((event, Some((tx.into(), msg_type))))
+            }
+            Err(err) => {
+                // return signing error such as no enough ckb
+                Err(err)
+            }
+        }
+    }
 }
 
 impl ChainEndpoint for Ckb4IbcChain {
@@ -624,119 +680,79 @@ impl ChainEndpoint for Ckb4IbcChain {
         &mut self,
         tracked_msgs: TrackedMsgs,
     ) -> Result<Vec<IbcEventWithHeight>, Error> {
-        let mut txs = Vec::new();
-        let mut tx_hashes = Vec::new();
-        let mut events = Vec::new();
         let mut result_events = Vec::new();
-        for msg in tracked_msgs.msgs {
-            let converter = self.get_converter()?;
-            let CkbTxInfo {
-                unsigned_tx,
-                envelope,
-                input_capacity,
-                event,
-            } = convert_msg_to_ckb_tx(msg, &converter)?;
-            if unsigned_tx.is_none() {
-                if let Some(e) = event {
-                    if let IbcEvent::CreateClient(e) = &e {
-                        let client_type = e.0.client_type;
-                        info!("the counterparty client type of Ckb4Ibc is set as {client_type}");
-                        self.sync_counterparty_client_type(client_type);
+        let mut msgs = tracked_msgs.msgs;
+        let mut retry_times = 0;
+        let sync_if_create_client = |event: &IbcEvent| {
+            if let IbcEvent::CreateClient(e) = event {
+                let client_type = e.0.client_type;
+                info!("counterparty client type of Ckb4Ibc is set to {client_type}");
+                self.sync_counterparty_client_type(client_type);
+                return true;
+            }
+            false
+        };
+        while !msgs.is_empty() {
+            let msg = msgs.remove(0);
+            match self.assemble_transaction_from_msg(&msg)? {
+                (Some(event), None) => {
+                    if sync_if_create_client(&event) {
+                        let ibc_event = IbcEventWithHeight::new(event, Height::default());
+                        return Ok(vec![ibc_event]);
+                    } else {
+                        return Ok(vec![]);
                     }
-                    let ibc_event = IbcEventWithHeight::new(e, Height::default());
-                    result_events.push(ibc_event);
                 }
-                continue;
-            }
-            let unsigned_tx = unsigned_tx.unwrap();
-            let msg_type = envelope.msg_type;
-            match self.complete_tx_with_secp256k1_change_and_envelope(
-                unsigned_tx,
-                input_capacity,
-                envelope,
-            ) {
-                Ok(tx) => {
-                    let last_input_idx = tx.inputs().len() - 1;
-                    let secret_key = self
-                        .keybase
-                        .get_key(&self.config.key_name)
-                        .map_err(Error::key_base)?
-                        .into_ckb_keypair(self.network()?)
-                        .private_key;
-                    let signer = SecpSighashScriptSigner::new(Box::new(
-                        SecpCkbRawKeySigner::new_with_secret_keys(vec![secret_key]),
-                    ));
-                    let tx = signer
-                        .sign_tx(
-                            &tx,
-                            &ScriptGroup {
-                                script: Script::from(&self.tx_assembler_address()?),
-                                group_type: ScriptGroupType::Lock,
-                                // TODO: here should be more indices in case of more than one Secp256k1 cells
-                                //       have been filled in the transaction
-                                input_indices: vec![last_input_idx],
-                                output_indices: vec![],
-                            },
-                        )
-                        .unwrap();
-                    tx_hashes.push(tx.hash().unpack());
-                    txs.push((tx, msg_type));
-                    events.push(event);
-                }
-                Err(err) => {
-                    // return signing error such as no enough ckb
-                    return Err(err);
-                }
-            }
-        }
-        let responses = txs.iter().map(|(tx, msg_type)| {
-            let tx: TransactionView = tx.clone().into();
-            self.rpc_client
-                .send_transaction(&tx.inner, None)
-                .and_then(|tx_hash| {
-                    let confirms = 3;
-                    info!(
-                        "{:?} transaction {} committed to {}, wait {confirms} blocks confirmation",
-                        *msg_type,
-                        hex::encode(&tx_hash),
-                        self.id()
-                    );
-                    wait_ckb_transaction_committed(
-                        &self.rpc_client,
-                        tx_hash,
-                        Duration::from_secs(10),
-                        confirms,
-                        Duration::from_secs(600),
-                    )
-                })
-        });
-        let responses = self.rt.block_on(futures::future::join_all(responses));
-        for (i, response) in responses.iter().enumerate() {
-            match response {
-                Ok(height) => {
-                    if let Some(event) = events.get(i).unwrap().clone() {
-                        if let IbcEvent::CreateClient(e) = &event {
-                            let client_type = e.0.client_type;
-                            info!(
-                                "the counterparty client type of Ckb4Ibc is set as {client_type}"
-                            );
-                            self.sync_counterparty_client_type(client_type);
+                (Some(event), Some((tx, msg_type))) => match self
+                    .rt
+                    .block_on(self.rpc_client.send_transaction(&tx.inner, None))
+                {
+                    Ok(tx_hash) => {
+                        let confirms = 3;
+                        info!(
+                            "{msg_type:?} transaction {} committed to {}, wait {confirms} blocks confirmation",
+                            hex::encode(&tx_hash),
+                            self.id()
+                        );
+                        retry_times = 0;
+                        match self.rt.block_on(wait_ckb_transaction_committed(
+                            &self.rpc_client,
+                            tx_hash.clone(),
+                            Duration::from_secs(10),
+                            confirms,
+                            Duration::from_secs(600),
+                        )) {
+                            Ok(height) => {
+                                sync_if_create_client(&event);
+                                let ibc_event_with_height = IbcEventWithHeight {
+                                    event,
+                                    height: Height::from_noncosmos_height(height),
+                                    tx_hash: tx_hash.0,
+                                };
+                                result_events.push(ibc_event_with_height);
+                            }
+                            Err(err) => {
+                                warn!("wait transaction failed: {err}");
+                                continue;
+                            }
                         }
-                        let tx_hash: [u8; 32] = tx_hashes.get(i).unwrap().clone().into();
-                        let ibc_event_with_height = IbcEventWithHeight {
-                            event,
-                            height: Height::from_noncosmos_height(*height),
-                            tx_hash,
-                        };
-                        result_events.push(ibc_event_with_height);
                     }
-                }
-                Err(e) => {
-                    let tx: TransactionView = txs[i].0.clone().into();
-                    let json_tx = serde_json::to_string_pretty(&tx).unwrap();
-                    let error = format!("{e}\n\n======== transaction info ========\n\n{json_tx}\n");
-                    return Err(Error::send_tx(error));
-                }
+                    Err(e) => {
+                        let json_tx = serde_json::to_string_pretty(&tx).unwrap();
+                        let error =
+                            format!("{e}\n\n======== transaction info ========\n\n{json_tx}\n");
+                        if error.contains("UnknowOutpoint") || error.contains("PoolRejectedRBF") {
+                            if retry_times < 3 {
+                                msgs.insert(0, msg);
+                            }
+                            retry_times += 1;
+                            warn!("error occurred, try again: {e}");
+                            continue;
+                        }
+                        return Err(Error::other_error(error));
+                    }
+                },
+                _ => unreachable!(),
             }
         }
         self.clear_cache();

--- a/crates/relayer/src/chain/ckb4ibc.rs
+++ b/crates/relayer/src/chain/ckb4ibc.rs
@@ -698,6 +698,7 @@ impl ChainEndpoint for Ckb4IbcChain {
                     .block_on(self.rpc_client.send_transaction(&tx.inner, None))
                 {
                     Ok(tx_hash) => {
+                        // TODO: put confirms count into config
                         let confirms = 3;
                         info!(
                             "{msg_type:?} transaction {} committed to {}, wait {confirms} blocks confirmation",
@@ -752,6 +753,9 @@ impl ChainEndpoint for Ckb4IbcChain {
         Ok(result_events)
     }
 
+    // FIXME: this method should be in non-blocking mode, but we can't be confident it
+    //        won't leave a protential issue if we do so, and working in blocking mode
+    //        is ok for now, so leave this comment to fix in upcomming days
     fn send_messages_and_wait_check_tx(
         &mut self,
         tracked_msgs: TrackedMsgs,

--- a/crates/relayer/src/chain/ckb4ibc/message.rs
+++ b/crates/relayer/src/chain/ckb4ibc/message.rs
@@ -325,7 +325,7 @@ pub struct CkbTxInfo {
 
 // Return a transaction which needs to be added relayer's input in it and to be signed.
 pub fn convert_msg_to_ckb_tx<C: MsgToTxConverter>(
-    msg: Any,
+    msg: &Any,
     converter: &C,
 ) -> Result<CkbTxInfo, Error> {
     match msg.type_url.as_str() {

--- a/crates/relayer/src/chain/ckb4ibc/message.rs
+++ b/crates/relayer/src/chain/ckb4ibc/message.rs
@@ -3,9 +3,7 @@ mod client;
 mod connection;
 mod packet;
 
-use std::{cell::Ref, collections::HashMap};
-
-use crate::{config::ckb4ibc::ChainConfig, error::Error, keyring::Secp256k1KeyPair};
+use crate::{config::ckb4ibc::ChainConfig, error::Error};
 use ckb_ics_axon::{
     handler::{IbcChannel, IbcConnections, IbcPacket},
     message::Envelope,
@@ -32,8 +30,6 @@ use ibc_relayer_types::{
         conn_open_try::MsgConnectionOpenTry, conn_open_try::TYPE_URL as CONN_OPEN_TRY_TYPE_URL,
     },
     core::{
-        ics02_client::client_type::ClientType,
-        ics03_connection::connection::IdentifiedConnectionEnd,
         ics04_channel::{
             msgs::{
                 acknowledgement::{MsgAcknowledgement, TYPE_URL as ACK_PACKET_TYPE_URL},
@@ -51,7 +47,6 @@ use ibc_relayer_types::{
             },
             packet::Sequence,
         },
-        ics23_commitment::commitment::CommitmentPrefix,
         ics24_host::identifier::{ChannelId, ConnectionId, PortId},
     },
     events::IbcEvent,
@@ -61,6 +56,7 @@ use ibc_relayer_types::{
 use super::{
     monitor::WriteAckMonitorCmd,
     utils::{generate_connection_id, get_script_hash},
+    Ckb4IbcChain,
 };
 use client::{convert_create_client, convert_update_client};
 
@@ -77,31 +73,33 @@ macro_rules! convert {
 }
 
 pub trait MsgToTxConverter {
-    fn get_key(&self) -> &Secp256k1KeyPair;
-
-    fn get_ibc_connections(&self, client_id: &str) -> Result<&IbcConnections, Error>;
+    fn get_ibc_connections(&self, client_id: &str) -> Result<IbcConnections, Error>;
 
     fn get_ibc_connections_by_connection_id(
         &self,
         connection_id: &ConnectionId,
-    ) -> Result<&IbcConnections, Error>;
+    ) -> Result<IbcConnections, Error>;
 
     fn get_ibc_connections_by_port_id(
         &self,
         channel_id: &ChannelId,
-    ) -> Result<&IbcConnections, Error>;
+    ) -> Result<IbcConnections, Error>;
 
-    fn get_ibc_connections_input(&self, client_id: &str) -> Result<(&CellInput, u64), Error>;
+    fn get_ibc_connections_input(&self, client_id: &str) -> Result<(CellInput, u64), Error>;
 
-    fn get_ibc_channel(&self, id: &ChannelId) -> Result<&IbcChannel, Error>;
+    fn get_ibc_channel(
+        &self,
+        channel_id: &ChannelId,
+        port: Option<&PortId>,
+    ) -> Result<IbcChannel, Error>;
 
     fn get_ibc_channel_input(
         &self,
         channel_id: &ChannelId,
         port_id: &PortId,
-    ) -> Result<(&CellInput, u64), Error>;
+    ) -> Result<(CellInput, u64), Error>;
 
-    fn get_client_outpoint(&self, client_id: &str) -> Option<&OutPoint>;
+    fn get_client_outpoint(&self, client_id: &str) -> Option<OutPoint>;
 
     fn get_conn_contract_outpoint(&self) -> &OutPoint;
 
@@ -119,15 +117,15 @@ pub trait MsgToTxConverter {
         &self,
         chan: &ChannelId,
         port: &PortId,
-        seq: &Sequence,
-    ) -> Result<(&CellInput, u64), Error>;
+        seq: Sequence,
+    ) -> Result<(CellInput, u64), Error>;
 
     fn get_ibc_packet(
         &self,
         chan: &ChannelId,
         port: &PortId,
-        seq: &Sequence,
-    ) -> Result<&IbcPacket, Error>;
+        seq: Sequence,
+    ) -> Result<IbcPacket, Error>;
 
     fn get_commitment_prefix(&self) -> Vec<u8>;
 
@@ -141,52 +139,44 @@ pub trait MsgToTxConverter {
 
 pub struct Converter<'a> {
     pub write_ack_cmd: &'a Option<WriteAckMonitorCmd>,
-    pub channel_input_data: Ref<'a, HashMap<(ChannelId, PortId), (CellInput, u64)>>,
-    pub channel_cache: Ref<'a, HashMap<ChannelId, IbcChannel>>,
-    #[allow(clippy::type_complexity)]
-    pub connection_cache: Ref<
-        'a,
-        HashMap<ClientType, (IbcConnections, CellInput, u64, Vec<IdentifiedConnectionEnd>)>,
-    >,
-    #[allow(clippy::type_complexity)]
-    pub packet_input_data: Ref<'a, HashMap<(ChannelId, PortId, Sequence), (CellInput, u64)>>,
-    pub packet_cache: Ref<'a, HashMap<(ChannelId, PortId, Sequence), IbcPacket>>,
-    pub config: &'a ChainConfig,
-    pub client_outpoints: Ref<'a, HashMap<ClientType, OutPoint>>,
-    pub chan_contract_outpoint: &'a OutPoint,
-    pub packet_contract_outpoint: &'a OutPoint,
-    pub conn_contract_outpoint: &'a OutPoint,
-    pub commitment_prefix: CommitmentPrefix,
+    pub ckb_instance: &'a Ckb4IbcChain,
 }
 
 impl<'a> MsgToTxConverter for Converter<'a> {
-    fn get_key(&self) -> &Secp256k1KeyPair {
-        todo!()
-    }
-
-    fn get_ibc_connections(&self, client_id: &str) -> Result<&IbcConnections, Error> {
-        let client_type = self.config.lc_client_type(client_id)?;
-        if let Some((connection, _, _, _)) = self.connection_cache.get(&client_type) {
-            Ok(connection)
-        } else {
-            Err(Error::query(format!(
-                "client_type {client_type} isn't in cache"
-            )))
+    fn get_ibc_connections(&self, client_id: &str) -> Result<IbcConnections, Error> {
+        let client_type = self.get_config().lc_client_type(client_id)?;
+        if let Some((connection, _, _, _)) = self
+            .ckb_instance
+            .connection_cache
+            .borrow()
+            .get(&client_type)
+        {
+            return Ok(connection.clone());
         }
+        self.ckb_instance.query_connection_and_cache()?;
+        let connection_cache = self.ckb_instance.connection_cache.borrow();
+        let (connection, _, _, _) =
+            connection_cache
+                .get(&client_type)
+                .ok_or(Error::query(format!(
+                    "client_type {client_type} isn't in cache"
+                )))?;
+        Ok(connection.clone())
     }
 
     fn get_ibc_connections_by_connection_id(
         &self,
         connection_id: &ConnectionId,
-    ) -> Result<&IbcConnections, Error> {
-        let ibc_connections = self.connection_cache.iter().find(|(_, (v, _, _, _))| {
+    ) -> Result<IbcConnections, Error> {
+        let conneciton_cache = self.ckb_instance.connection_cache.borrow();
+        let ibc_connections = conneciton_cache.iter().find(|(_, (v, _, _, _))| {
             v.connections
                 .iter()
                 .enumerate()
                 .any(|(idx, c)| connection_id == &generate_connection_id(idx as u16, &c.client_id))
         });
         if let Some((_, (value, _, _, _))) = ibc_connections {
-            Ok(value)
+            Ok(value.clone())
         } else {
             Err(Error::query(format!(
                 "connection {connection_id} not found in cache"
@@ -197,9 +187,9 @@ impl<'a> MsgToTxConverter for Converter<'a> {
     fn get_ibc_connections_by_port_id(
         &self,
         channel_id: &ChannelId,
-    ) -> Result<&IbcConnections, Error> {
-        let channel = self
-            .channel_cache
+    ) -> Result<IbcConnections, Error> {
+        let channel_cache = self.ckb_instance.channel_cache.borrow();
+        let channel = channel_cache
             .get(channel_id)
             .ok_or_else(|| Error::query(format!("channel {channel_id} not found in cache")))?;
         // FIXME: should modify ibc contract
@@ -207,74 +197,129 @@ impl<'a> MsgToTxConverter for Converter<'a> {
         self.get_ibc_connections_by_connection_id(&connection_id)
     }
 
-    fn get_ibc_connections_input(&self, client_id: &str) -> Result<(&CellInput, u64), Error> {
-        let client_type = self.config.lc_client_type(client_id)?;
-        if let Some((_, cell_input, capacity, _)) = self.connection_cache.get(&client_type) {
-            Ok((cell_input, *capacity))
-        } else {
-            Err(Error::query(format!(
-                "client_type {client_type} isn't in cache"
-            )))
+    fn get_ibc_connections_input(&self, client_id: &str) -> Result<(CellInput, u64), Error> {
+        let client_type = self.get_config().lc_client_type(client_id)?;
+        if let Some((_, cell_input, capacity, _)) = self
+            .ckb_instance
+            .connection_cache
+            .borrow()
+            .get(&client_type)
+        {
+            return Ok((cell_input.clone(), *capacity));
         }
+        self.ckb_instance.query_connection_and_cache()?;
+        let connection_cache = self.ckb_instance.connection_cache.borrow();
+        let (_, cell_input, capacity, _) =
+            connection_cache
+                .get(&client_type)
+                .ok_or(Error::query(format!(
+                    "client_type {client_type} isn't in cache"
+                )))?;
+        Ok((cell_input.clone(), *capacity))
     }
 
-    fn get_ibc_channel(&self, channel_id: &ChannelId) -> Result<&IbcChannel, Error> {
-        self.channel_cache
-            .get(channel_id)
-            .ok_or(Error::query(format!("no channel_id {channel_id}")))
+    fn get_ibc_channel(
+        &self,
+        channel_id: &ChannelId,
+        port_id: Option<&PortId>,
+    ) -> Result<IbcChannel, Error> {
+        if let Some(channel) = self.ckb_instance.channel_cache.borrow().get(channel_id) {
+            return Ok(channel.clone());
+        }
+        if let Some(port_id) = port_id {
+            self.ckb_instance
+                .fetch_channel_cell_and_extract(channel_id, port_id, true)?;
+            self.ckb_instance
+                .channel_cache
+                .borrow()
+                .get(channel_id)
+                .ok_or(Error::query(format!("no channel_id {channel_id}")))
+                .cloned()
+        } else {
+            Err(Error::query(format!("no channel_id {channel_id}")))
+        }
     }
 
     fn get_ibc_channel_input(
         &self,
         channel_id: &ChannelId,
         port_id: &PortId,
-    ) -> Result<(&CellInput, u64), Error> {
-        self.channel_input_data
+    ) -> Result<(CellInput, u64), Error> {
+        if let Some((input, capacity)) = self
+            .ckb_instance
+            .channel_input_data
+            .borrow()
             .get(&(channel_id.clone(), port_id.clone()))
-            .map(|(input, capacity)| (input, *capacity))
+        {
+            return Ok((input.clone(), *capacity));
+        }
+        self.ckb_instance
+            .fetch_channel_cell_and_extract(channel_id, port_id, true)?;
+        self.ckb_instance
+            .channel_input_data
+            .borrow()
+            .get(&(channel_id.clone(), port_id.clone()))
+            .map(|(input, capacity)| (input.clone(), *capacity))
             .ok_or(Error::query(format!("no channel({channel_id}/{port_id})")))
     }
 
-    fn get_client_outpoint(&self, client_id: &str) -> Option<&OutPoint> {
-        let Some(client_type) = self.config.lc_client_type(client_id).ok() else {
+    fn get_client_outpoint(&self, client_id: &str) -> Option<OutPoint> {
+        let Some(client_type) = self.get_config().lc_client_type(client_id).ok() else {
             return None;
         };
-        self.client_outpoints.get(&client_type)
+        self.ckb_instance
+            .client_outpoints
+            .borrow()
+            .get(&client_type)
+            .cloned()
     }
 
     fn get_conn_contract_outpoint(&self) -> &OutPoint {
-        self.conn_contract_outpoint
+        &self.ckb_instance.connection_outpoint
     }
 
     fn get_chan_contract_outpoint(&self) -> &OutPoint {
-        self.chan_contract_outpoint
+        &self.ckb_instance.channel_outpoint
     }
 
     fn get_packet_contract_outpoint(&self) -> &OutPoint {
-        self.packet_contract_outpoint
+        &self.ckb_instance.packet_outpoint
     }
 
     fn get_channel_code_hash(&self) -> Byte32 {
-        get_script_hash(&self.config.channel_type_args)
+        get_script_hash(&self.get_config().channel_type_args)
     }
 
     fn get_packet_code_hash(&self) -> Byte32 {
-        get_script_hash(&self.config.packet_type_args)
+        get_script_hash(&self.get_config().packet_type_args)
     }
 
     fn get_connection_code_hash(&self) -> Byte32 {
-        get_script_hash(&self.config.connection_type_args)
+        get_script_hash(&self.get_config().connection_type_args)
     }
 
     fn get_ibc_packet_input(
         &self,
         channel_id: &ChannelId,
         port_id: &PortId,
-        sequence: &Sequence,
-    ) -> Result<(&CellInput, u64), Error> {
-        self.packet_input_data
-            .get(&(channel_id.clone(), port_id.clone(), *sequence))
-            .map(|(input, capacity)| (input, *capacity))
+        sequence: Sequence,
+    ) -> Result<(CellInput, u64), Error> {
+        if let Some((input, capacity)) = self
+            .ckb_instance
+            .packet_input_data
+            .borrow()
+            .get(&(channel_id.clone(), port_id.clone(), sequence))
+            .map(|(input, capacity)| (input.clone(), *capacity))
+        {
+            return Ok((input, capacity));
+        }
+        self.ckb_instance
+            .fetch_packet_cells_and_extract(channel_id, port_id, Some(sequence))?;
+        self.ckb_instance
+            .packet_input_data
+            .borrow()
+            .get(&(channel_id.clone(), port_id.clone(), sequence))
+            .map(|(input, capacity)| (input.clone(), *capacity))
             .ok_or(Error::query(format!(
                 "no packet({channel_id}/{port_id}/{sequence})"
             )))
@@ -284,21 +329,33 @@ impl<'a> MsgToTxConverter for Converter<'a> {
         &self,
         channel_id: &ChannelId,
         port_id: &PortId,
-        sequence: &Sequence,
-    ) -> Result<&IbcPacket, Error> {
-        self.packet_cache
-            .get(&(channel_id.clone(), port_id.clone(), *sequence))
+        sequence: Sequence,
+    ) -> Result<IbcPacket, Error> {
+        if let Some(packet) = self.ckb_instance.packet_cache.borrow().get(&(
+            channel_id.clone(),
+            port_id.clone(),
+            sequence,
+        )) {
+            return Ok(packet.clone());
+        }
+        self.ckb_instance
+            .fetch_packet_cells_and_extract(channel_id, port_id, Some(sequence))?;
+        self.ckb_instance
+            .packet_cache
+            .borrow()
+            .get(&(channel_id.clone(), port_id.clone(), sequence))
             .ok_or(Error::query(format!(
                 "no packet({channel_id}/{port_id}/{sequence})"
             )))
+            .cloned()
     }
 
     fn get_commitment_prefix(&self) -> Vec<u8> {
-        self.commitment_prefix.as_bytes().to_vec()
+        self.get_config().store_prefix.clone().into_bytes()
     }
 
     fn get_config(&self) -> &ChainConfig {
-        self.config
+        &self.ckb_instance.config
     }
 
     fn require_useless_write_ack_packet(

--- a/crates/relayer/src/chain/ckb4ibc/message/channel.rs
+++ b/crates/relayer/src/chain/ckb4ibc/message/channel.rs
@@ -115,7 +115,7 @@ pub fn convert_chan_open_init_to_tx<C: MsgToTxConverter>(
         port_id: convert_port_id_to_array(&msg.port_id)?,
     };
 
-    let old_connection = get_encoded_object(old_connection_cell);
+    let old_connection = get_encoded_object(&old_connection_cell);
     let new_connection = get_encoded_object(&new_connection_cell);
     let connection_lock =
         get_connection_lock_script(converter.get_config(), Some(client_id.clone()))?;
@@ -164,7 +164,7 @@ pub fn convert_chan_open_try_to_tx<C: MsgToTxConverter>(
     let ibc_channel = get_encoded_object(&ibc_channel_end);
 
     let (client_cell_type_args, client_id) = get_client_id_from_channel(&msg.channel, converter)?;
-    let old_connection = get_encoded_object(old_connection_cell);
+    let old_connection = get_encoded_object(&old_connection_cell);
     let new_connection = get_encoded_object(&new_connection_cell);
 
     let envelope = Envelope {
@@ -217,7 +217,7 @@ pub fn convert_chan_open_ack_to_tx<C: MsgToTxConverter>(
     converter: &C,
 ) -> Result<CkbTxInfo, Error> {
     let channel_idx = get_channel_number(&msg.channel_id)?;
-    let old_channel = converter.get_ibc_channel(&msg.channel_id)?;
+    let old_channel = converter.get_ibc_channel(&msg.channel_id, None)?;
     let counterparty_port_id = PortId::from_str(&old_channel.counterparty.port_id).unwrap();
     let mut new_channel = old_channel.clone();
     new_channel.state = CkbState::Open;
@@ -242,7 +242,7 @@ pub fn convert_chan_open_ack_to_tx<C: MsgToTxConverter>(
     };
 
     let channel_lock = get_channel_lock_script(converter, channel_args.to_args());
-    let old_channel = get_encoded_object(old_channel);
+    let old_channel = get_encoded_object(&old_channel);
     let new_channel = get_encoded_object(&new_channel);
     let (channel_input, input_capacity) =
         converter.get_ibc_channel_input(&msg.channel_id, &msg.port_id)?;
@@ -276,7 +276,7 @@ pub fn convert_chan_open_confirm_to_tx<C: MsgToTxConverter>(
     msg: MsgChannelOpenConfirm,
     converter: &C,
 ) -> Result<CkbTxInfo, Error> {
-    let old_channel = converter.get_ibc_channel(&msg.channel_id)?;
+    let old_channel = converter.get_ibc_channel(&msg.channel_id, None)?;
     let mut new_channel = old_channel.clone();
     new_channel.state = CkbState::Open;
 
@@ -304,7 +304,7 @@ pub fn convert_chan_open_confirm_to_tx<C: MsgToTxConverter>(
     };
 
     let channel_lock = get_channel_lock_script(converter, channel_args.to_args());
-    let old_channel = get_encoded_object(old_channel);
+    let old_channel = get_encoded_object(&old_channel);
     let new_channel = get_encoded_object(&new_channel);
     let (channel_input, input_capacity) =
         converter.get_ibc_channel_input(&msg.channel_id, &msg.port_id)?;

--- a/crates/relayer/src/chain/ckb4ibc/message/connection.rs
+++ b/crates/relayer/src/chain/ckb4ibc/message/connection.rs
@@ -58,7 +58,7 @@ pub fn convert_conn_open_init_to_tx<C: MsgToTxConverter>(
         content: rlp::encode(&CkbMsgConnectionOpenInit {}).to_vec(),
     };
 
-    let old_connection = get_encoded_object(old_ibc_connection_cell);
+    let old_connection = get_encoded_object(&old_ibc_connection_cell);
     let new_connection = get_encoded_object(&new_ibc_connection_cell);
     let connection_lock =
         get_connection_lock_script(converter.get_config(), Some(client_id.clone()))?;
@@ -123,7 +123,7 @@ pub fn convert_conn_open_try_to_tx<C: MsgToTxConverter>(
         .to_vec(),
     };
 
-    let old_connection = get_encoded_object(old_ibc_connection_cell);
+    let old_connection = get_encoded_object(&old_ibc_connection_cell);
     let new_connection = get_encoded_object(&new_ibc_connection_cell);
     let connection_lock =
         get_connection_lock_script(converter.get_config(), Some(client_id.clone()))?;
@@ -177,7 +177,7 @@ pub fn convert_conn_open_ack_to_tx<C: MsgToTxConverter>(
     let counterparty_client_id = connection_end.counterparty.client_id.clone();
     let client_id = connection_end.client_id.clone();
 
-    let old_connection = get_encoded_object(old_ibc_connection_cell);
+    let old_connection = get_encoded_object(&old_ibc_connection_cell);
     let new_connection = get_encoded_object(&new_ibc_connection_cell);
     let connection_lock =
         get_connection_lock_script(converter.get_config(), Some(client_id.clone()))?;
@@ -235,7 +235,7 @@ pub fn convert_conn_open_confirm_to_tx<C: MsgToTxConverter>(
         .map(|v| v.parse().unwrap());
     let client_id = connection_end.client_id.clone();
 
-    let old_connection = get_encoded_object(old_ibc_connection_cell);
+    let old_connection = get_encoded_object(&old_ibc_connection_cell);
     let new_connection = get_encoded_object(&new_ibc_connection_cell);
     let connection_lock =
         get_connection_lock_script(converter.get_config(), Some(client_id.clone()))?;

--- a/crates/relayer/src/chain/ckb4ibc/utils.rs
+++ b/crates/relayer/src/chain/ckb4ibc/utils.rs
@@ -242,7 +242,6 @@ pub fn get_client_outpoint(
 ) -> Result<OutPoint, Error> {
     converter
         .get_client_outpoint(client_id)
-        .cloned()
         .ok_or(Error::other_error(format!("not found {client_id}")))
 }
 


### PR DESCRIPTION
## background
We found the running Forcerelay faces two major problems, which are about the stability of monitor and transaction sending feature.

Monitor of Axon has an unstable problem about the disconnection in logs listener, it frequently missed essential events from Axon which will block the entire relay process.

Transaction assembly in CKB could take `RBF` and `UnknowOutpoint` problems, which are caused by the cell compete, and to solve the compete condition should put huge effort on redesigning the structure of IBC cells, so as the best method is to resend unworkable transactions.

## change logs
1. refactor transaction assembly process in CKB to add `retry` feature
2. optimize message convertor of CKB to fetch live IBC cells immediately once miss the peak in corresponding cells cache, because if retry the assembly of transaction, it should rerun the assembly process which would kick out dead cells from caches
3. refactor monitor logic of Axon to use POLL process to take place of the LISTEN process

## closed PRs
- #373 