### PR TITLE
chore: add git commit hash into ibc-relayer version string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2925,7 +2925,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "forcerelay-ckb-sdk"
 version = "0.1.0"
-source = "git+https://github.com/synapseweb3/forcerelay-ckb-sdk?rev=61a78aa#61a78aaa2a4fb1609aa97196b50aa45f6c084f66"
+source = "git+https://github.com/synapseweb3/forcerelay-ckb-sdk?rev=cd29a30b350ab853a496a58b970017bfa1249182#cd29a30b350ab853a496a58b970017bfa1249182"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/relayer/build.rs
+++ b/crates/relayer/build.rs
@@ -1,3 +1,5 @@
+// note: the same as build.rs in `ibc-relayer-cli` crate
+
 use std::env;
 
 use git::Handle as GitHandle;
@@ -8,7 +10,7 @@ fn main() {
     // outputs consistent usage and help messages.
     // https://github.com/informalsystems/hermes/issues/590
     // Note: This can potentially break the normal cargo (or crates.io) workflow.
-    println!("cargo:rustc-env=CARGO_PKG_NAME=forcerelay");
+    // println!("cargo:rustc-env=CARGO_PKG_NAME=forcerelay");
     println!("cargo:rustc-env=CARGO_PKG_VERSION={}", version());
 }
 


### PR DESCRIPTION
## background
We don't know how to clarify the git commit of a running Forcerelay instance, which would take a block to our further debug

The Forcerelay has already integrated REST-API feature while compiling and can just open it for changing the REST flag from `false` to `true` in config

Through `/version` api, the response contains version information without git commit hash, this should be adjusted

## change logs
1. add git commit hash into the version printing of `ibc-relayer`

## how's it work
via: http://127.0.0.1:3000/version
<img width="834" alt="image" src="https://github.com/synapseweb3/forcerelay/assets/3871265/1c0a3330-44e5-4ad9-a43e-57472ab110e3">
